### PR TITLE
task: Ease dev host name constraints

### DIFF
--- a/pkg/op/config.go
+++ b/pkg/op/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/url"
 	"os"
-	"strings"
 
 	"golang.org/x/text/language"
 )
@@ -57,9 +56,5 @@ func devLocalAllowed(url *url.URL) bool {
 	if !b {
 		return b
 	}
-	return url.Scheme == "http" &&
-		url.Host == "localhost" ||
-		url.Host == "127.0.0.1" ||
-		url.Host == "::1" ||
-		strings.HasPrefix(url.Host, "localhost:")
+	return url.Scheme == "http"
 }


### PR DESCRIPTION
This changes the requirements for the issuer hostname to allow anything that is `http`. The reason for this is because the user of the library already has to make a conscious decision to set `CAOS_OIDC_DEV` so they should already understand the risks of not using `https`. 

The primary motivation for this change is to allow IdPs to be created in a containerized integration test environment. Specifically setting up a docker compose file that starts all parts of the system with a test IdP using this library where the DNS name will not be `localhost`.