### PR TITLE
feat: allow library users to specify how PKCE challenge codes are generated

### DIFF
--- a/example/client/github/github.go
+++ b/example/client/github/github.go
@@ -43,7 +43,7 @@ func main() {
 	state := func() string {
 		return uuid.New().String()
 	}
-	token := cli.CodeFlow(relyingParty, callbackPath, port, state)
+	token := cli.CodeFlow(ctx, relyingParty, callbackPath, port, state)
 
 	client := github.NewClient(relyingParty.OAuthConfig().Client(ctx, token.Token))
 


### PR DESCRIPTION
First off, thanks for your work on this library - much appreciated and great to see it is certified.

I'm raising this PR to give consumers more control over how PKCE challenge codes are generated. Currently PKCE challenge codes in the latest release are UUIDs (in master they are Base64 URL encoded UUIDs) and the library user has no way to change this. However, a consumer may need to for the following reasons:

1. An OIDC provider only accepts challenge codes of certain lengths or using certain alphabets. Okta, for instance, rejects PKCE challenge codes shorter than 43 characters.
2. A library consumer may wish to fine tune the security of the challenge code - for instance, by using a specific source of randomness or by choosing longer or shorter challenge codes depending on.

This PR demonstrates a possible approach to allowing consumers to control how PKCE challenge codes are generated. I don't necessarily expect you to accept it as is - although I've tried to match the coding style used in the rest of this repo, this is a bit of a drive-by PR to try to solve a problem I'm facing right now and potentially breaks any custom implementations consumers have of the RelyingParty interface by adding a new method to it. However hopefully it helps get to a place where consumers have more control over PKCE challenge code generation.