### PR TITLE
fix: allowed ConcatenateJSON with empty input

### DIFF
--- a/pkg/utils/marshal.go
+++ b/pkg/utils/marshal.go
@@ -29,6 +29,14 @@ func ConcatenateJSON(first, second []byte) ([]byte, error) {
 	if !bytes.HasPrefix(second, []byte{'{'}) {
 		return nil, fmt.Errorf("jws: invalid JSON %s", second)
 	}
+	// check empty
+	if len(first) == 2 {
+		return second, nil
+	}
+	if len(second) == 2 {
+		return first, nil
+	}
+
 	first[len(first)-1] = ','
 	first = append(first, second[1:]...)
 	return first, nil

--- a/pkg/utils/marshal_test.go
+++ b/pkg/utils/marshal_test.go
@@ -44,6 +44,36 @@ func TestConcatenateJSON(t *testing.T) {
 			[]byte(`{"some": "thing","another": "thing"}`),
 			false,
 		},
+		{
+			"first empty",
+			args{
+				[]byte(`{}`),
+				[]byte(`{"some": "thing"}`),
+			},
+
+			[]byte(`{"some": "thing"}`),
+			false,
+		},
+		{
+			"second empty",
+			args{
+				[]byte(`{"some": "thing"}`),
+				[]byte(`{}`),
+			},
+
+			[]byte(`{"some": "thing"}`),
+			false,
+		},
+		{
+			"both empty",
+			args{
+				[]byte(`{}`),
+				[]byte(`{}`),
+			},
+
+			[]byte(`{}`),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -53,7 +83,7 @@ func TestConcatenateJSON(t *testing.T) {
 				return
 			}
 			if !bytes.Equal(got, tt.want) {
-				t.Errorf("ConcatenateJSON() got = %v, want %v", got, tt.want)
+				t.Errorf("ConcatenateJSON() got = %v, want %v", string(got), tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
idTokenClaims with empty userinfo will generate invalid json