### PR TITLE
feat(rp): Adding end_session endpoint to relaying party interface

### DIFF
--- a/pkg/client/rp/relaying_party.go
+++ b/pkg/client/rp/relaying_party.go
@@ -50,6 +50,9 @@ type RelyingParty interface {
 	//Signer is used if the relaying party uses the JWT Profile
 	Signer() jose.Signer
 
+	//GetEndSessionEndpoint returns the endpoint to sign out on a IDP
+	GetEndSessionEndpoint() string
+
 	//UserinfoEndpoint returns the userinfo
 	UserinfoEndpoint() string
 

--- a/pkg/client/rp/relaying_party.go
+++ b/pkg/client/rp/relaying_party.go
@@ -117,6 +117,10 @@ func (rp *relyingParty) UserinfoEndpoint() string {
 	return rp.endpoints.UserinfoURL
 }
 
+func (rp *relyingParty) GetEndSessionEndpoint() string {
+	return rp.endpoints.EndSessionURL
+}
+
 func (rp *relyingParty) IDTokenVerifier() IDTokenVerifier {
 	if rp.idTokenVerifier == nil {
 		rp.idTokenVerifier = NewIDTokenVerifier(rp.issuer, rp.oauthConfig.ClientID, NewRemoteKeySet(rp.httpClient, rp.endpoints.JKWsURL), rp.verifierOpts...)

--- a/pkg/client/rp/relaying_party.go
+++ b/pkg/client/rp/relaying_party.go
@@ -476,6 +476,7 @@ type Endpoints struct {
 	IntrospectURL string
 	UserinfoURL   string
 	JKWsURL       string
+	EndSessionURL string
 }
 
 func GetEndpoints(discoveryConfig *oidc.DiscoveryConfiguration) Endpoints {
@@ -488,6 +489,7 @@ func GetEndpoints(discoveryConfig *oidc.DiscoveryConfiguration) Endpoints {
 		IntrospectURL: discoveryConfig.IntrospectionEndpoint,
 		UserinfoURL:   discoveryConfig.UserinfoEndpoint,
 		JKWsURL:       discoveryConfig.JwksURI,
+		EndSessionURL: discoveryConfig.EndSessionEndpoint,
 	}
 }
 


### PR DESCRIPTION
In my case here I had to have a way to know what would be the endpoint for signing out. 
I realized that the library doesn't expose this endpoint in the rp package. So what I did was add a new function in the interface and create a new field to expose the end session endpoint. 

I'm opening here this Pull request just for you all to do an analysis and see if it breaks any concepts regarding the OpenID Connect.

If it breaks anything (in the concept) please let me know why.

By the way, thank you all for maintaining this project, that is really nice.  