### PR TITLE
chore: add comments documenting Storage and AuthStorage

### DIFF
--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -20,9 +20,6 @@ type AuthStorage interface {
 	//
 	// * TokenRequest as returned by ClientCredentialsStorage.ClientCredentialsTokenRequest,
 	//
-	// * RefreshTokenRequest as returned by AuthStorage.TokenRequestByRefreshToken
-	//   (CreateAccessAndRefreshTokens will also be called)
-	//
 	// * AuthRequest as returned by AuthRequestByID or AuthRequestByCode (above)
 	//
 	// * *oidc.JWTTokenRequest from a JWT that is the assertion value of a JWT Profile


### PR DESCRIPTION
Working to implement the Storage interfaces, I found myself puzzled over what I could count on for `TokenRequest` beyond it's minimal interface.  It's minimal interface isn't rich enough for me to implement `CreateAccessToken`.   I've tried to address that with a comment, but a change in the API would be better (yeah,I know that would break backwards compatibility; sometimes that needs to happen).

Are my comments accurate?    What flow results in creating an access token after decoding a JWT?

Thanks

Note: I'm building a federated identity server so requests to my OP will trigger an outbound request as an OIDC RP or as a SAML SP depending on the SSO setup for that particular user.  After I get things working, I expect to try to make a change so that the OP /callback can be combined into the success handlers for the client authentication callbacks and thus avoid an intra-server redirect.
