### PR TITLE
feat: Add db scanner methods for SpaceDelimitedArray

### DIFF
--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -32,6 +32,11 @@ const (
 	ClientAssertionTypeJWTAssertion = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 )
 
+var AllGrantTypes = []GrantType{
+	GrantTypeCode, GrantTypeRefreshToken, GrantTypeClientCredentials,
+	GrantTypeBearer, GrantTypeTokenExchange, GrantTypeImplicit,
+	ClientAssertionTypeJWTAssertion}
+
 type GrantType string
 
 type TokenRequest interface {

--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -1,7 +1,9 @@
 package oidc
 
 import (
+	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -93,6 +95,34 @@ func (s *SpaceDelimitedArray) UnmarshalJSON(data []byte) error {
 	}
 	*s = strings.Split(str, " ")
 	return nil
+}
+
+func (s *SpaceDelimitedArray) Scan(src interface{}) error {
+	if src == nil {
+		*s = nil
+		return nil
+	}
+	switch v := src.(type) {
+	case string:
+		if len(v) == 0 {
+			*s = SpaceDelimitedArray{}
+			return nil
+		}
+		*s = strings.Split(v, " ")
+	case []byte:
+		if len(v) == 0 {
+			*s = SpaceDelimitedArray{}
+			return nil
+		}
+		*s = strings.Split(string(v), " ")
+	default:
+		return fmt.Errorf("cannot convert %T to SpaceDelimitedArray", src)
+	}
+	return nil
+}
+
+func (s SpaceDelimitedArray) Value() (driver.Value, error) {
+	return strings.Join(s, " "), nil
 }
 
 type Time time.Time


### PR DESCRIPTION
I've added methods to `SpaceDelimitedArray` to allow it t be easily marshaled and unmarshaled via SQL.

I also added an array of the GrantTypes to help with the same.   This code is not yet in production on my side.

See https://husobee.github.io/golang/database/2015/06/12/scanner-valuer.html for a discussion of Scan/Value.

It would also be helpful to use an enumer (eg https://github.com/alvaroloes/enumer) to provide enum <-> string transformations for the various types that are defined with `iota` like `op.AccessTokenType` and `op.ApplicationType` that are required for third parties to implement some of the required interfaces.   There is positive feedback to for the idea of adding an enumer, I'm happy to do so, but I didn't want to assume that would be well received. 