### PR TITLE
fix: nil pointer dereference on UserInfoAddress (option 2)

### DIFF
--- a/pkg/oidc/userinfo.go
+++ b/pkg/oidc/userinfo.go
@@ -259,27 +259,27 @@ func (u *userinfo) AppendClaims(key string, value interface{}) {
 	u.claims[key] = value
 }
 
-func (u *userInfoAddress) GetFormatted() string {
+func (u userInfoAddress) GetFormatted() string {
 	return u.Formatted
 }
 
-func (u *userInfoAddress) GetStreetAddress() string {
+func (u userInfoAddress) GetStreetAddress() string {
 	return u.StreetAddress
 }
 
-func (u *userInfoAddress) GetLocality() string {
+func (u userInfoAddress) GetLocality() string {
 	return u.Locality
 }
 
-func (u *userInfoAddress) GetRegion() string {
+func (u userInfoAddress) GetRegion() string {
 	return u.Region
 }
 
-func (u *userInfoAddress) GetPostalCode() string {
+func (u userInfoAddress) GetPostalCode() string {
 	return u.PostalCode
 }
 
-func (u *userInfoAddress) GetCountry() string {
+func (u userInfoAddress) GetCountry() string {
 	return u.Country
 }
 
@@ -334,7 +334,7 @@ type userInfoAddress struct {
 }
 
 func NewUserInfoAddress(streetAddress, locality, region, postalCode, country, formatted string) UserInfoAddress {
-	return &userInfoAddress{
+	return userInfoAddress{
 		StreetAddress: streetAddress,
 		Locality:      locality,
 		Region:        region,
@@ -380,7 +380,7 @@ func (u *userinfo) MarshalJSON() ([]byte, error) {
 func (u *userinfo) UnmarshalJSON(data []byte) error {
 	type Alias userinfo
 	a := &struct {
-		Address *userInfoAddress `json:"address,omitempty"`
+		Address userInfoAddress `json:"address,omitempty"`
 		*Alias
 		UpdatedAt int64 `json:"update_at,omitempty"`
 	}{

--- a/pkg/oidc/userinfo_test.go
+++ b/pkg/oidc/userinfo_test.go
@@ -81,3 +81,35 @@ func TestUserInfoEmailVerifiedUnmarshal(t *testing.T) {
 		}, uie)
 	})
 }
+
+// issue 203 test case.
+func Test_userinfo_GetAddress_issue_203(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "with address",
+			data: `{"address":{"street_address":"Test 789\nPostfach 2"},"email":"test","email_verified":true,"name":"Test","phone_number":"0791234567","phone_number_verified":true,"private_claim":"test","sub":"test"}`,
+		},
+		{
+			name: "without address",
+			data: `{"email":"test","email_verified":true,"name":"Test","phone_number":"0791234567","phone_number_verified":true,"private_claim":"test","sub":"test"}`,
+		},
+		{
+			name: "null address",
+			data: `{"address":null,"email":"test","email_verified":true,"name":"Test","phone_number":"0791234567","phone_number_verified":true,"private_claim":"test","sub":"test"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &userinfo{}
+			if err := json.Unmarshal([]byte(tt.data), info); err != nil {
+				t.Fatal(err)
+			}
+
+			info.GetAddress().GetCountry() //<- used to panic
+		})
+	}
+}


### PR DESCRIPTION
This is an alternative to #207, where `userInfoAddress` is no longer accessed through pointers. This makes it always safe for acces. IMHO this is a slightly cleaner approach because we don't need to `if`/`else`.