### PR TITLE
chore: update jwtProfileKeySet to match actual use

### DIFF
--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -139,7 +139,7 @@ func ParseRequestObject(ctx context.Context, authReq *oidc.AuthRequest, storage 
 	if !str.Contains(requestObject.Audience, issuer) {
 		return authReq, oidc.ErrInvalidRequest()
 	}
-	keySet := &jwtProfileKeySet{storage, requestObject.Issuer}
+	keySet := &jwtProfileKeySet{storage: storage, clientID: requestObject.Issuer}
 	if err = oidc.CheckSignature(ctx, authReq.RequestParam, payload, requestObject, nil, keySet); err != nil {
 		return authReq, err
 	}

--- a/pkg/op/verifier_jwt_profile.go
+++ b/pkg/op/verifier_jwt_profile.go
@@ -96,8 +96,7 @@ func VerifyJWTAssertion(ctx context.Context, assertion string, v JWTProfileVerif
 		return nil, err
 	}
 
-	keySet := &jwtProfileKeySet{v.Storage(), request.Issuer}
-
+	keySet := &jwtProfileKeySet{storage: v.Storage(), clientID: request.Issuer}
 	if err = oidc.CheckSignature(ctx, assertion, payload, request, nil, keySet); err != nil {
 		return nil, err
 	}
@@ -116,14 +115,14 @@ func SubjectIsIssuer(request *oidc.JWTTokenRequest) error {
 }
 
 type jwtProfileKeySet struct {
-	storage jwtProfileKeyStorage
-	userID  string
+	storage  jwtProfileKeyStorage
+	clientID string
 }
 
 //VerifySignature implements oidc.KeySet by getting the public key from Storage implementation
 func (k *jwtProfileKeySet) VerifySignature(ctx context.Context, jws *jose.JSONWebSignature) (payload []byte, err error) {
 	keyID, _ := oidc.GetKeyIDAndAlg(jws)
-	key, err := k.storage.GetKeyByIDAndUserID(ctx, keyID, k.userID)
+	key, err := k.storage.GetKeyByIDAndUserID(ctx, keyID, k.clientID)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching keys: %w", err)
 	}


### PR DESCRIPTION
What is actually stored in `jwtProfileKeySet` is a client id.  It is not a user id. 
This change makes no functional difference, it just removes some naming technical debt.