### PR TITLE
fix: avoid potential race conditions

### DIFF
--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -190,6 +190,10 @@ func NewRelyingPartyOIDC(issuer, clientID, clientSecret, redirectURI string, sco
 	rp.oauthConfig.Endpoint = endpoints.Endpoint
 	rp.endpoints = endpoints
 
+	// avoid races by calling these early
+	_ = rp.IDTokenVerifier() // sets idTokenVerifier
+	_ = rp.ErrorHandler()    // sets errorHandler
+
 	return rp, nil
 }
 

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -154,6 +154,8 @@ func NewRelyingPartyOAuth(config *oauth2.Config, options ...Option) (RelyingPart
 		}
 	}
 
+	_ = rp.IDTokenVerifier()
+
 	return rp, nil
 }
 

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -154,7 +154,9 @@ func NewRelyingPartyOAuth(config *oauth2.Config, options ...Option) (RelyingPart
 		}
 	}
 
-	_ = rp.IDTokenVerifier()
+	// avoid races by calling these early
+	_ = rp.IDTokenVerifier() // sets idTokenVerifier
+	_ = rp.ErrorHandler()    // sets errorHandler
 
 	return rp, nil
 }

--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -167,9 +167,10 @@ func NewOpenIDProvider(ctx context.Context, config *Config, storage Storage, opO
 	o.crypto = NewAESCrypto(config.CryptoKey)
 
 	// Avoid potential race conditions by calling these early
-	_ = o.AccessTokenVerifier()
-	_ = o.JWTProfileVerifier()
-	_ = o.openIDKeySet()
+	_ = o.AccessTokenVerifier() // sets accessTokenVerifier
+	_ = o.IDTokenHintVerifier() // sets idTokenHintVerifier
+	_ = o.JWTProfileVerifier()  // sets jwtProfileVerifier
+	_ = o.openIDKeySet()        // sets keySet
 
 	return o, nil
 }

--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -166,6 +166,11 @@ func NewOpenIDProvider(ctx context.Context, config *Config, storage Storage, opO
 
 	o.crypto = NewAESCrypto(config.CryptoKey)
 
+	// Avoid potential race conditions by calling these early
+	_ = o.AccessTokenVerifier()
+	_ = o.JWTProfileVerifier()
+	_ = o.openIDKeySet()
+
 	return o, nil
 }
 


### PR DESCRIPTION
This change avoids five potential race conditions.

Lazy initializes in `RelyingParty` and `OpenIDProvider` operate without locks.  Rather than adding locks, I simply moved the initialization to when the object is created.

The  OpenIDProvider signer updates when there is new data in a channel.  It was doing its work without a lock.  For that one, I added a lock.