### PR TITLE
add access token verifier ops to openidProvider

### DIFF
--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -170,20 +170,21 @@ func NewOpenIDProvider(ctx context.Context, config *Config, storage Storage, opO
 }
 
 type openidProvider struct {
-	config              *Config
-	endpoints           *endpoints
-	storage             Storage
-	signer              Signer
-	idTokenHintVerifier IDTokenHintVerifier
-	jwtProfileVerifier  JWTProfileVerifier
-	accessTokenVerifier AccessTokenVerifier
-	keySet              *openIDKeySet
-	crypto              Crypto
-	httpHandler         http.Handler
-	decoder             *schema.Decoder
-	encoder             *schema.Encoder
-	interceptors        []HttpInterceptor
-	timer               <-chan time.Time
+	config                  *Config
+	endpoints               *endpoints
+	storage                 Storage
+	signer                  Signer
+	idTokenHintVerifier     IDTokenHintVerifier
+	jwtProfileVerifier      JWTProfileVerifier
+	accessTokenVerifier     AccessTokenVerifier
+	keySet                  *openIDKeySet
+	crypto                  Crypto
+	httpHandler             http.Handler
+	decoder                 *schema.Decoder
+	encoder                 *schema.Encoder
+	interceptors            []HttpInterceptor
+	timer                   <-chan time.Time
+	accessTokenVerifierOpts []AccessTokenVerifierOpt
 }
 
 func (o *openidProvider) Issuer() string {
@@ -448,6 +449,13 @@ func WithCustomEndpoints(auth, token, userInfo, revocation, endSession, keys End
 func WithHttpInterceptors(interceptors ...HttpInterceptor) Option {
 	return func(o *openidProvider) error {
 		o.interceptors = append(o.interceptors, interceptors...)
+		return nil
+	}
+}
+
+func WithAccessTokenVerifierOpts(opts ...AccessTokenVerifierOpt) Option {
+	return func(o *openidProvider) error {
+		o.accessTokenVerifierOpts = opts
 		return nil
 	}
 }

--- a/pkg/op/verifier_access_token.go
+++ b/pkg/op/verifier_access_token.go
@@ -48,10 +48,21 @@ func (i *accessTokenVerifier) KeySet() oidc.KeySet {
 	return i.keySet
 }
 
-func NewAccessTokenVerifier(issuer string, keySet oidc.KeySet) AccessTokenVerifier {
+type AccessTokenVerifierOpt func(*accessTokenVerifier)
+
+func WithSupportedAccessTokenSigningAlgorithms(algs ...string) AccessTokenVerifierOpt {
+	return func(verifier *accessTokenVerifier) {
+		verifier.supportedSignAlgs = algs
+	}
+}
+
+func NewAccessTokenVerifier(issuer string, keySet oidc.KeySet, opts ...AccessTokenVerifierOpt) AccessTokenVerifier {
 	verifier := &accessTokenVerifier{
 		issuer: issuer,
 		keySet: keySet,
+	}
+	for _, opt := range opts {
+		opt(verifier)
 	}
 	return verifier
 }


### PR DESCRIPTION
For various reasons, I'm not using RS256.   While `RelyingParty` had a way to specify that other `alg`s could be used, OpenIDProivder did not.    This change adds the ability to user other crypto algorithms.

Just as an aside, why not have the default accept more algorithms?   RS384, RS512, ES256, ES384, ES512 at least.