### PR TITLE
chore: adjustments to comments for things found while implementing Storage

### DIFF
--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -248,6 +248,8 @@ func WithClientKey(path string) Option {
 }
 
 // WithJWTProfile creates a signer used for the JWT Profile Client Authentication on the token endpoint
+// When creating the signer, be sure to include the KeyID in the SigningKey.
+// See client.NewSignerFromPrivateKeyByte for an example.
 func WithJWTProfile(signerFromKey SignerFromKey) Option {
 	return func(rp *relyingParty) error {
 		signer, err := signerFromKey()

--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -70,6 +70,8 @@ func (a *AccessTokenRequest) SetClientSecret(clientSecret string) {
 	a.ClientSecret = clientSecret
 }
 
+// RefreshTokenRequest is not useful for making refresh requests because the
+// grant_type is not included explicitly but rather implied.
 type RefreshTokenRequest struct {
 	RefreshToken        string              `schema:"refresh_token"`
 	Scopes              SpaceDelimitedArray `schema:"scope"`

--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -133,7 +133,8 @@ type endpoints struct {
 //This does not include login. Login is handled with a redirect that includes the
 //request ID. The redirect for logins is specified per-client by Client.LoginURL().
 //Successful logins should mark the request as authorized and redirect back to to
-//op.AuthCallbackURL(provider) which is probably /callback.
+//op.AuthCallbackURL(provider) which is probably /callback. On the redirect back
+// to the AuthCallbackURL, the request id should be passed as the "id" parameter.
 func NewOpenIDProvider(ctx context.Context, config *Config, storage Storage, opOpts ...Option) (OpenIDProvider, error) {
 	err := ValidateIssuer(config.Issuer)
 	if err != nil {

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -56,7 +56,10 @@ type OPStorage interface {
 	SetUserinfoFromToken(ctx context.Context, userinfo oidc.UserInfoSetter, tokenID, subject, origin string) error
 	SetIntrospectionFromToken(ctx context.Context, userinfo oidc.IntrospectionResponse, tokenID, subject, clientID string) error
 	GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (map[string]interface{}, error)
-	GetKeyByIDAndUserID(ctx context.Context, keyID, userID string) (*jose.JSONWebKey, error)
+
+	// GetKeyByIDAndUserID is mis-named.  It does not pass userID.  Instead
+	// it passes the clientID.
+	GetKeyByIDAndUserID(ctx context.Context, keyID, clientID string) (*jose.JSONWebKey, error)
 	ValidateJWTProfileScopes(ctx context.Context, userID string, scopes []string) ([]string, error)
 }
 


### PR DESCRIPTION
As I implemented and debugged `op.Storage`, there were a few things that I noticed that caused me to update comments.  These are those updates.

The most significant thing I noticed was that `GetKeyByIDAndUserID` is misnamed.   It should be called `GetKeyByIDAndClientID` instead.    Please add that to whatever list is kept for breaking changes that are waiting for the next major release.

