### PR TITLE
docs(README.md): fix typos 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Check the `/example` folder where example code for different scenarios is locate
 # oidc discovery http://localhost:9998/.well-known/openid-configuration
 go run github.com/zitadel/oidc/example/server
 # start oidc web client
-CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998/ SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/example/client/app
+CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998 SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/example/client/app
 ```
 
 - open http://localhost:9999/login in your browser


### PR DESCRIPTION
The issuer should be http://localhost:9998 NOT the http://localhost:9998/

```bash
curl http://localhost:9998/.well-known/openid-configuration
```
```json
{
   "issuer":"http://localhost:9998",
   "authorization_endpoint":"http://localhost:9998/auth",
   "token_endpoint":"http://localhost:9998/oauth/token",
   "introspection_endpoint":"http://localhost:9998/oauth/introspect",
   "userinfo_endpoint":"http://localhost:9998/userinfo",
   "revocation_endpoint":"http://localhost:9998/revoke",
   "end_session_endpoint":"http://localhost:9998/end_session",
   "jwks_uri":"http://localhost:9998/keys",
   "scopes_supported":[
      "openid",
      "profile",
      "email",
      "phone",
      "address",
      "offline_access"
   ],
   "response_types_supported":[
      "code",
      "id_token",
      "id_token token"
   ],
   "grant_types_supported":[
      "authorization_code",
      "implicit",
      "refresh_token",
      "urn:ietf:params:oauth:grant-type:jwt-bearer"
   ],
   "subject_types_supported":[
      "public"
   ],
   "id_token_signing_alg_values_supported":[
      "RS256"
   ],
   "request_object_signing_alg_values_supported":[
      "RS256"
   ],
   "token_endpoint_auth_methods_supported":[
      "none",
      "client_secret_basic",
      "client_secret_post",
      "private_key_jwt"
   ],
   "token_endpoint_auth_signing_alg_values_supported":[
      "RS256"
   ],
   "revocation_endpoint_auth_methods_supported":[
      "none",
      "client_secret_basic",
      "client_secret_post",
      "private_key_jwt"
   ],
   "revocation_endpoint_auth_signing_alg_values_supported":[
      "RS256"
   ],
   "introspection_endpoint_auth_methods_supported":[
      "client_secret_basic",
      "private_key_jwt"
   ],
   "introspection_endpoint_auth_signing_alg_values_supported":[
      "RS256"
   ],
   "claims_supported":[
      "sub",
      "aud",
      "exp",
      "iat",
      "iss",
      "auth_time",
      "nonce",
      "acr",
      "amr",
      "c_hash",
      "at_hash",
      "act",
      "scopes",
      "client_id",
      "azp",
      "preferred_username",
      "name",
      "family_name",
      "given_name",
      "locale",
      "email",
      "email_verified",
      "phone_number",
      "phone_number_verified"
   ],
   "code_challenge_methods_supported":[
      "S256"
   ],
   "ui_locales_supported":[
      "en"
   ],
   "request_parameter_supported":true,
   "request_uri_parameter_supported":false
}
```


Before
```bash
CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998/ SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/example/client/app

FATA[0000] error creating provider issuer does not match
exit status 1
```

After 
```
CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998 SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/example/client/app

INFO[0000] listening on http://127.0.0.1:9999/
```