### PR TITLE
feat: allow id token hint verifier to specify algs

### DIFF
--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -192,6 +192,7 @@ type openidProvider struct {
 	interceptors            []HttpInterceptor
 	timer                   <-chan time.Time
 	accessTokenVerifierOpts []AccessTokenVerifierOpt
+	idTokenHintVerifierOpts     []IDTokenHintVerifierOpt
 }
 
 func (o *openidProvider) Issuer() string {
@@ -301,7 +302,7 @@ func (o *openidProvider) Encoder() httphelper.Encoder {
 
 func (o *openidProvider) IDTokenHintVerifier() IDTokenHintVerifier {
 	if o.idTokenHintVerifier == nil {
-		o.idTokenHintVerifier = NewIDTokenHintVerifier(o.Issuer(), o.openIDKeySet())
+		o.idTokenHintVerifier = NewIDTokenHintVerifier(o.Issuer(), o.openIDKeySet(), o.idTokenHintVerifierOpts...)
 	}
 	return o.idTokenHintVerifier
 }
@@ -463,6 +464,13 @@ func WithHttpInterceptors(interceptors ...HttpInterceptor) Option {
 func WithAccessTokenVerifierOpts(opts ...AccessTokenVerifierOpt) Option {
 	return func(o *openidProvider) error {
 		o.accessTokenVerifierOpts = opts
+		return nil
+	}
+}
+
+func WithIDTokenHintVerifierOpts(opts ...IDTokenHintVerifierOpt) Option {
+	return func(o *openidProvider) error {
+		o.idTokenHintVerifierOpts = opts
 		return nil
 	}
 }

--- a/pkg/op/verifier_id_token_hint.go
+++ b/pkg/op/verifier_id_token_hint.go
@@ -53,10 +53,21 @@ func (i *idTokenHintVerifier) MaxAge() time.Duration {
 	return i.maxAge
 }
 
-func NewIDTokenHintVerifier(issuer string, keySet oidc.KeySet) IDTokenHintVerifier {
+type IDTokenHintVerifierOpt func(*idTokenHintVerifier)
+
+func WithSupportedIDTokenHintSigningAlgorithms(algs ...string) IDTokenHintVerifierOpt {
+	return func(verifier *idTokenHintVerifier) {
+		verifier.supportedSignAlgs = algs
+	}
+}
+
+func NewIDTokenHintVerifier(issuer string, keySet oidc.KeySet, opts ...IDTokenHintVerifierOpt) IDTokenHintVerifier {
 	verifier := &idTokenHintVerifier{
 		issuer: issuer,
 		keySet: keySet,
+	}
+	for _, opt := range opts {
+		opt(verifier)
 	}
 	return verifier
 }


### PR DESCRIPTION
I found another place where my use of algorithms other than RS256 causes trouble...

This adds support for specifying the support algorithms for the IDTokenHintVerifier

This is tested by automated tests in a private repo.