### PR TITLE
feat: add rp.RevokeToken

### DIFF
--- a/NEXT_RELEASE.md
+++ b/NEXT_RELEASE.md
@@ -1,0 +1,6 @@
+
+# Backwards-incompatible changes to be made in the next major release
+
+- Add `rp/RelyingParty.GetRevokeEndpoint`
+- Rename `op/OpStorage.GetKeyByIDAndUserID` to `op/OpStorage.GetKeyByIDAndClientID` 
+

--- a/example/server/storage/storage.go
+++ b/example/server/storage/storage.go
@@ -255,11 +255,11 @@ func (s *Storage) TerminateSession(ctx context.Context, userID string, clientID 
 
 // RevokeToken implements the op.Storage interface
 // it will be called after parsing and validation of the token revocation request
-func (s *Storage) RevokeToken(ctx context.Context, token string, userID string, clientID string) *oidc.Error {
+func (s *Storage) RevokeToken(ctx context.Context, tokenIDOrToken string, userID string, clientID string) *oidc.Error {
 	// a single token was requested to be removed
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	accessToken, ok := s.tokens[token]
+	accessToken, ok := s.tokens[tokenIDOrToken] // tokenID
 	if ok {
 		if accessToken.ApplicationID != clientID {
 			return oidc.ErrInvalidClient().WithDescription("token was not issued for this client")
@@ -269,7 +269,7 @@ func (s *Storage) RevokeToken(ctx context.Context, token string, userID string, 
 		delete(s.tokens, accessToken.ID)
 		return nil
 	}
-	refreshToken, ok := s.refreshTokens[token]
+	refreshToken, ok := s.refreshTokens[tokenIDOrToken] // token
 	if !ok {
 		// if the token is neither an access nor a refresh token, just ignore it, the expected behaviour of
 		// being not valid (anymore) is achieved

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -85,6 +85,11 @@ func CallEndSessionEndpoint(request interface{}, authFn interface{}, caller EndS
 	if err != nil {
 		return nil, err
 	}
+	client := caller.HttpClient()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := client.Do(req)
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		// TODO: switch to io.ReadAll when go1.15 support is retired

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -85,11 +85,6 @@ func CallEndSessionEndpoint(request interface{}, authFn interface{}, caller EndS
 	if err != nil {
 		return nil, err
 	}
-	client := caller.HttpClient()
-	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-	resp, err := client.Do(req)
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		// TODO: switch to io.ReadAll when go1.15 support is retired
@@ -107,6 +102,47 @@ func CallEndSessionEndpoint(request interface{}, authFn interface{}, caller EndS
 		return nil, err
 	}
 	return location, nil
+}
+
+type RevokeCaller interface {
+	GetRevokeEndpoint() string
+	HttpClient() *http.Client
+}
+
+type RevokeRequest struct {
+	Token         string `schema:"token"`
+	TokenTypeHint string `schema:"token_type_hint"`
+	ClientID      string `schema:"client_id"`
+	ClientSecret  string `schema:"client_secret"`
+}
+
+func CallRevokeEndpoint(request interface{}, authFn interface{}, caller RevokeCaller) error {
+	req, err := httphelper.FormRequest(caller.GetRevokeEndpoint(), request, Encoder, authFn)
+	if err != nil {
+		return err
+	}
+	client := caller.HttpClient()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// According to RFC7009 in section 2.2:
+	// "The content of the response body is ignored by the client as all
+	// necessary information is conveyed in the response code."
+	if resp.StatusCode != 200 {
+		// TODO: switch to io.ReadAll when go1.15 support is retired
+		body, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			return fmt.Errorf("revoke returned status %d and text: %s", resp.StatusCode, string(body))
+		} else {
+			return fmt.Errorf("revoke returned status %d", resp.StatusCode)
+		}
+	}
+	return nil
 }
 
 func NewSignerFromPrivateKeyByte(key []byte, keyID string) (jose.Signer, error) {

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -39,7 +39,12 @@ type AuthStorage interface {
 	TokenRequestByRefreshToken(ctx context.Context, refreshTokenID string) (RefreshTokenRequest, error)
 
 	TerminateSession(ctx context.Context, userID string, clientID string) error
-	RevokeToken(ctx context.Context, tokenID string, userID string, clientID string) *oidc.Error
+
+	// RevokeToken should revoke a token. In the situation that the original request was to
+	// revoke an access token, then tokenOrTokenID will be a tokenID and userID will be set
+	// but if the original request was for a refresh token, then userID will be empty and
+	// tokenOrTokenID will be the refresh token, not its ID.
+	RevokeToken(ctx context.Context, tokenOrTokenID string, userID string, clientID string) *oidc.Error
 
 	GetSigningKey(context.Context, chan<- jose.SigningKey)
 	GetKeySet(context.Context) (*jose.JSONWebKeySet, error)

--- a/pkg/op/token_revocation.go
+++ b/pkg/op/token_revocation.go
@@ -113,8 +113,11 @@ func ParseTokenRevocationRequest(r *http.Request, revoker Revoker) (token, token
 func RevocationRequestError(w http.ResponseWriter, r *http.Request, err error) {
 	e := oidc.DefaultToServerError(err, err.Error())
 	status := http.StatusBadRequest
-	if e.ErrorType == oidc.InvalidClient {
+	switch e.ErrorType {
+	case oidc.InvalidClient:
 		status = 401
+	case oidc.ServerError:
+		status = 500
 	}
 	httphelper.MarshalJSONWithStatus(w, e, status)
 }


### PR DESCRIPTION
This adds a `RevokeToken()` function to the `rp` package.

Most of the implementation is inside `client`.   It also adjusts the documentation of the `Storage.RevokeToken` to reflect that the first argument can either be a token or a token id and that the second argument, the `userID` is sometimes empty.

`op.Revoke()` will now use status code 500 for server errors.

Lastly, a new markdown file is added that lists things to adjust with the next major release.  Listing these in advance allows implementors to be compatible ahead of time.

These changes are tested by automated tests in a private repo. 