### PR TITLE
chore: add op.AllAuthMethods

### DIFF
--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -157,3 +157,7 @@ const (
 	AuthMethodNone          AuthMethod = "none"
 	AuthMethodPrivateKeyJWT AuthMethod = "private_key_jwt"
 )
+
+var AllAuthMethods = []AuthMethod{
+	AuthMethodBasic, AuthMethodPost, AuthMethodNone, AuthMethodPrivateKeyJWT,
+}


### PR DESCRIPTION
Adds an array of auth methods so that anyone wanting to validate an auth method can do so relatively easily.
