### PR TITLE
feat: add CanRefreshTokenInfo to support non-JWT refresh tokens 

### DIFF
--- a/NEXT_RELEASE.md
+++ b/NEXT_RELEASE.md
@@ -3,4 +3,5 @@
 
 - Add `rp/RelyingParty.GetRevokeEndpoint`
 - Rename `op/OpStorage.GetKeyByIDAndUserID` to `op/OpStorage.GetKeyByIDAndClientID` 
+- Add `CanRefreshTokenInfo` (`GetRefreshTokenInfo()`) to `op.Storage`
 

--- a/pkg/oidc/error.go
+++ b/pkg/oidc/error.go
@@ -18,7 +18,6 @@ const (
 	InteractionRequired  errorType = "interaction_required"
 	LoginRequired        errorType = "login_required"
 	RequestNotSupported  errorType = "request_not_supported"
-	InvalidRefreshToken  errorType = "invalid_refresh_token"
 )
 
 var (
@@ -76,11 +75,6 @@ var (
 	ErrRequestNotSupported = func() *Error {
 		return &Error{
 			ErrorType: RequestNotSupported,
-		}
-	}
-	ErrInvalidRefreshToken = func() *Error {
-		return &Error{
-			ErrorType: InvalidRefreshToken,
 		}
 	}
 )

--- a/pkg/oidc/error.go
+++ b/pkg/oidc/error.go
@@ -18,6 +18,7 @@ const (
 	InteractionRequired  errorType = "interaction_required"
 	LoginRequired        errorType = "login_required"
 	RequestNotSupported  errorType = "request_not_supported"
+	InvalidRefreshToken  errorType = "invalid_refresh_token"
 )
 
 var (
@@ -75,6 +76,11 @@ var (
 	ErrRequestNotSupported = func() *Error {
 		return &Error{
 			ErrorType: RequestNotSupported,
+		}
+	}
+	ErrInvalidRefreshToken = func() *Error {
+		return &Error{
+			ErrorType: InvalidRefreshToken,
 		}
 	}
 )

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -51,8 +51,8 @@ type AuthStorage interface {
 }
 
 // CanRefreshTokenInfo is an optional additional interface that Storage can support.
-// Supporting CanRefreshTokenInfo is required to be able to revoke a refresh token that
-// does not happen to also be JWTs.
+// Supporting CanRefreshTokenInfo is required to be able to (revoke) a refresh token that
+// is neither an encrypted string of <tokenID>:<userID> nor a JWT.
 type CanRefreshTokenInfo interface {
 	// GetRefreshTokenInfo must return oidc.ErrInvalidRefreshToken when presented
 	// with a token that is not a refresh token.

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -50,6 +50,15 @@ type AuthStorage interface {
 	GetKeySet(context.Context) (*jose.JSONWebKeySet, error)
 }
 
+// CanRefreshTokenInfo is an optional additional interface that Storage can support.
+// Supporting CanRefreshTokenInfo is required to be able to revoke a refresh token that
+// does not happen to also be JWTs.
+type CanRefreshTokenInfo interface {
+	// GetRefreshTokenInfo must return oidc.ErrInvalidRefreshToken when presented
+	// with a token that is not a refresh token.
+	GetRefreshTokenInfo(ctx context.Context, clientID string, token string) (userID string, tokenID string, err error)
+}
+
 type ClientCredentialsStorage interface {
 	ClientCredentialsTokenRequest(ctx context.Context, clientID string, scopes []string) (TokenRequest, error)
 }

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -54,7 +54,7 @@ type AuthStorage interface {
 // Supporting CanRefreshTokenInfo is required to be able to (revoke) a refresh token that
 // is neither an encrypted string of <tokenID>:<userID> nor a JWT.
 type CanRefreshTokenInfo interface {
-	// GetRefreshTokenInfo must return oidc.ErrInvalidRefreshToken when presented
+	// GetRefreshTokenInfo must return ErrInvalidRefreshToken when presented
 	// with a token that is not a refresh token.
 	GetRefreshTokenInfo(ctx context.Context, clientID string, token string) (userID string, tokenID string, err error)
 }

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"gopkg.in/square/go-jose.v2"
@@ -58,6 +59,8 @@ type CanRefreshTokenInfo interface {
 	// with a token that is not a refresh token.
 	GetRefreshTokenInfo(ctx context.Context, clientID string, token string) (userID string, tokenID string, err error)
 }
+
+var ErrInvalidRefreshToken = errors.New("invalid_refresh_token")
 
 type ClientCredentialsStorage interface {
 	ClientCredentialsTokenRequest(ctx context.Context, clientID string, scopes []string) (TokenRequest, error)

--- a/pkg/op/token_revocation.go
+++ b/pkg/op/token_revocation.go
@@ -31,6 +31,8 @@ func revocationHandler(revoker Revoker) func(http.ResponseWriter, *http.Request)
 	}
 }
 
+var ErrInvalidRefreshToken = errors.New("invalid_refresh_token")
+
 func Revoke(w http.ResponseWriter, r *http.Request, revoker Revoker) {
 	token, tokenTypeHint, clientID, err := ParseTokenRevocationRequest(r, revoker)
 	if err != nil {
@@ -43,7 +45,7 @@ func Revoke(w http.ResponseWriter, r *http.Request, revoker Revoker) {
 		userID, tokenID, err := canRefreshInfo.GetRefreshTokenInfo(r.Context(), clientID, token)
 		if err != nil {
 			// An invalid refresh token means that we'll try other things (leaving doDecrypt==true)
-			if !errors.Is(err, oidc.ErrInvalidRefreshToken()) {
+			if !errors.Is(err, ErrInvalidRefreshToken) {
 				RevocationRequestError(w, r, oidc.ErrServerError().WithParent(err))
 				return
 			}

--- a/pkg/op/token_revocation.go
+++ b/pkg/op/token_revocation.go
@@ -31,8 +31,6 @@ func revocationHandler(revoker Revoker) func(http.ResponseWriter, *http.Request)
 	}
 }
 
-var ErrInvalidRefreshToken = errors.New("invalid_refresh_token")
-
 func Revoke(w http.ResponseWriter, r *http.Request, revoker Revoker) {
 	token, tokenTypeHint, clientID, err := ParseTokenRevocationRequest(r, revoker)
 	if err != nil {


### PR DESCRIPTION
Add an additional, optional, op.Storage interface so that refresh tokens
that are not JWTs do not cause failures when they randomly, sometimes, decrypt without error

```go
// CanRefreshTokenInfo is an optional additional interface that Storage can support.
// Supporting CanRefreshTokenInfo is required to be able to revoke a refresh token that
// does not happen to also be a JWTs work properly.
type CanRefreshTokenInfo interface {
        // GetRefreshTokenInfo must return oidc.ErrInvalidRefreshToken when presented
	// with a token that is not a refresh token.
	GetRefreshTokenInfo(ctx context.Context, clientID string, token string) (userID string, tokenID string, err error)
}
```

This will have a minor conflict with #231: both add NEXT_RELEASE.md.  This branch has the version that should be kept.