### PR TITLE
doc: document lack of client caching

### DIFF
--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -67,6 +67,8 @@ type ClientCredentialsStorage interface {
 }
 
 type OPStorage interface {
+	// GetClientByClientID loads a Client. The returned Client is never cached and is only used to
+	// handle the current request.
 	GetClientByClientID(ctx context.Context, clientID string) (Client, error)
 	AuthorizeClientIDSecret(ctx context.Context, clientID, clientSecret string) error
 	SetUserinfoFromScopes(ctx context.Context, userinfo oidc.UserInfoSetter, userID, clientID string, scopes []string) error


### PR DESCRIPTION
My implementation of `OPStorage` now depends upon behavior that is not currently documented.  This change simply documents that behavior.

Why would I do this?  Well, I want to pass additional information from the `/authorize` request though such that the `LoginURL` is completely different.   I do this by pulling information out of the `http.Request` before `op.Authorize` sees the request.  I add that info to the request `Context` and then use that information when handling the `GetClientByClientID` call so that I can later adjust what `LoginURL` does.   Yes, that's a bit hacky, but it's all good as long as the returned client is never cached.
