### PR TITLE
chore: switch from iouitil to io.ReadAll

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.15', '1.16', '1.17', '1.18', '1.19']
+        go: ['1.16', '1.17', '1.18', '1.19']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ Versions that also build are marked with :warning:.
 
 | Version | Supported          |
 |---------|--------------------|
-| <1.15   | :x:                |
-| 1.15    | :warning:          |
+| <1.16   | :x:                |
 | 1.16    | :warning:          |
 | 1.17    | :warning:          |
 | 1.18    | :white_check_mark: |

--- a/example/client/service/service.go
+++ b/example/client/service/service.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -71,7 +71,7 @@ func main() {
 			}
 			defer file.Close()
 
-			key, err := ioutil.ReadAll(file)
+			key, err := io.ReadAll(file)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -161,7 +161,7 @@ func callExampleEndpoint(client *http.Client, testURL string) (interface{}, erro
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zitadel/oidc
 
-go 1.15
+go 1.16
 
 require (
 	github.com/golang/mock v1.6.0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -92,8 +92,7 @@ func CallEndSessionEndpoint(request interface{}, authFn interface{}, caller EndS
 	resp, err := client.Do(req)
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		// TODO: switch to io.ReadAll when go1.15 support is retired
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -139,8 +138,7 @@ func CallRevokeEndpoint(request interface{}, authFn interface{}, caller RevokeCa
 	// "The content of the response body is ignored by the client as all
 	// necessary information is conveyed in the response code."
 	if resp.StatusCode != 200 {
-		// TODO: switch to io.ReadAll when go1.15 support is retired
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err == nil {
 			return fmt.Errorf("revoke returned status %d and text: %s", resp.StatusCode, string(body))
 		} else {

--- a/pkg/client/rp/integration_test.go
+++ b/pkg/client/rp/integration_test.go
@@ -3,6 +3,7 @@ package rp_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -209,8 +210,7 @@ func getRedirect(t *testing.T, desc string, httpClient *http.Client, uri *url.UR
 
 	defer func() {
 		if t.Failed() {
-			// TODO: switch to io.ReadAll when go1.15 support is dropped
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			t.Logf("%s: GET %s: body: %s", desc, uri, string(body))
 		}
 	}()
@@ -233,8 +233,7 @@ func getForm(t *testing.T, desc string, httpClient *http.Client, uri *url.URL) [
 	require.NoErrorf(t, err, "%s: GET %s", desc, uri)
 	//nolint:errcheck
 	defer resp.Body.Close()
-	// TODO: switch to io.ReadAll when go1.15 support is dropped
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, "%s: read GET %s", desc, uri)
 	return body
 }
@@ -256,8 +255,7 @@ func fillForm(t *testing.T, desc string, httpClient *http.Client, body []byte, u
 	defer resp.Body.Close()
 	defer func() {
 		if t.Failed() {
-			// TODO: switch to io.ReadAll when go1.15 support is dropped
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			t.Logf("%s: GET %s: body: %s", desc, uri, string(body))
 		}
 	}()

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -60,7 +60,7 @@ func HttpRequest(client *http.Client, req *http.Request, response interface{}) e
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("unable to read response body: %v", err)
 	}


### PR DESCRIPTION
removed a TODO: switch to io.ReadAll and drop go1.15 support