### PR TITLE
chore: add go 1.20 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.16', '1.17', '1.18', '1.19']
+        go: ['1.16', '1.17', '1.18', '1.19', '1.20']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Versions that also build are marked with :warning:.
 | <1.16   | :x:                |
 | 1.16    | :warning:          |
 | 1.17    | :warning:          |
-| 1.18    | :white_check_mark: |
+| 1.18    | :warning:          |
 | 1.19    | :white_check_mark: |
+| 1.20    | :white_check_mark: |
 
 ## Why another library
 


### PR DESCRIPTION
Resubmit to `next` branch