### PR TITLE
docs: update example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Check the `/example` folder where example code for different scenarios is locate
 # oidc discovery http://localhost:9998/.well-known/openid-configuration
 go run github.com/zitadel/oidc/v2/example/server
 # start oidc web client (in a new terminal)
-CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998 SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/example/client/app
+CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998/ SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/v2/example/client/app
 ```
 
 - open http://localhost:9999/login in your browser

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	//we will run on :9998
 	port := "9998"
-	//which gives us the issuer: //http://localhost:9998/
+	//which gives us the issuer: http://localhost:9998/
 	issuer := fmt.Sprintf("http://localhost:%s/", port)
 
 	// the OpenIDProvider interface needs a Storage interface handling various checks and state manipulations


### PR DESCRIPTION
Updates docs to run the example server.
The `example/client/app` was failing with:

```
FATA[0000] error creating provider issuer does not match 
exit status 1
```

Due to mismatch of traling slash in `ISSUER`.