### PR TITLE
fix: use the same schema encoder everywhere

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,11 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 	"time"
 
-	"github.com/gorilla/schema"
 	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2"
 
@@ -21,13 +19,7 @@ import (
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 )
 
-var Encoder = func() httphelper.Encoder {
-	e := schema.NewEncoder()
-	e.RegisterEncoder(oidc.SpaceDelimitedArray{}, func(value reflect.Value) string {
-		return value.Interface().(oidc.SpaceDelimitedArray).Encode()
-	})
-	return e
-}()
+var Encoder = httphelper.Encoder(oidc.NewEncoder())
 
 // Discover calls the discovery endpoint of the provided issuer and returns its configuration
 // It accepts an optional argument "wellknownUrl" which can be used to overide the dicovery endpoint url

--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -4,9 +4,11 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
+	"github.com/gorilla/schema"
 	"golang.org/x/text/language"
 	"gopkg.in/square/go-jose.v2"
 )
@@ -123,6 +125,16 @@ func (s *SpaceDelimitedArray) Scan(src interface{}) error {
 
 func (s SpaceDelimitedArray) Value() (driver.Value, error) {
 	return strings.Join(s, " "), nil
+}
+
+// NewEncoder returns a schema Encoder with
+// a registered encoder for SpaceDelimitedArray.
+func NewEncoder() *schema.Encoder {
+	e := schema.NewEncoder()
+	e.RegisterEncoder(SpaceDelimitedArray{}, func(value reflect.Value) string {
+		return value.Interface().(SpaceDelimitedArray).Encode()
+	})
+	return e
 }
 
 type Time time.Time

--- a/pkg/oidc/types_test.go
+++ b/pkg/oidc/types_test.go
@@ -3,10 +3,12 @@ package oidc
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/gorilla/schema"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
 )
@@ -334,4 +336,21 @@ func TestSpaceDelimitatedArray_ValuerNil(t *testing.T) {
 	if assert.NoError(t, err, "Scan nil") {
 		assert.Equal(t, SpaceDelimitedArray(nil), reversed, "scan nil")
 	}
+}
+
+func TestNewEncoder(t *testing.T) {
+	type request struct {
+		Scopes SpaceDelimitedArray `schema:"scope"`
+	}
+	a := request{
+		Scopes: SpaceDelimitedArray{"foo", "bar"},
+	}
+
+	values := make(url.Values)
+	NewEncoder().Encode(a, values)
+	assert.Equal(t, url.Values{"scope": []string{"foo bar"}}, values)
+
+	var b request
+	schema.NewDecoder().Decode(&b, values)
+	assert.Equal(t, a, b)
 }

--- a/pkg/op/device_test.go
+++ b/pkg/op/device_test.go
@@ -98,8 +98,6 @@ func TestParseDeviceCodeRequest(t *testing.T) {
 			name:    "empty request",
 			wantErr: true,
 		},
-		/* decoding a SpaceDelimitedArray is broken
-		https://github.com/zitadel/oidc/issues/295
 		{
 			name: "success",
 			req: &oidc.DeviceAuthorizationRequest{
@@ -107,7 +105,6 @@ func TestParseDeviceCodeRequest(t *testing.T) {
 				ClientID: "web",
 			},
 		},
-		*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -189,7 +189,7 @@ func newProvider(ctx context.Context, config *Config, storage Storage, issuer fu
 	o.decoder = schema.NewDecoder()
 	o.decoder.IgnoreUnknownKeys(true)
 
-	o.encoder = schema.NewEncoder()
+	o.encoder = oidc.NewEncoder()
 
 	o.crypto = NewAESCrypto(config.CryptoKey)
 


### PR DESCRIPTION
Properly register SpaceDelimitedArray for all instances
of schema.Encoder inside the oidc framework.

Closes #295