### PR TITLE
auto install things for "go generate" and then clean up afterwards

### DIFF
--- a/pkg/op/client.go
+++ b/pkg/op/client.go
@@ -13,6 +13,7 @@ import (
 
 //go:generate go get github.com/dmarkham/enumer
 //go:generate go run github.com/dmarkham/enumer -linecomment -sql -json -text -yaml -gqlgen -type=ApplicationType,AccessTokenType
+//go:generate go mod tidy
 
 const (
 	ApplicationTypeWeb       ApplicationType = iota // web

--- a/pkg/op/mock/configuration.mock.go
+++ b/pkg/op/mock/configuration.mock.go
@@ -400,20 +400,6 @@ func (mr *MockConfigurationMockRecorder) TokenEndpointSigningAlgorithmsSupported
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokenEndpointSigningAlgorithmsSupported", reflect.TypeOf((*MockConfiguration)(nil).TokenEndpointSigningAlgorithmsSupported))
 }
 
-// UserCodeFormEndpoint mocks base method.
-func (m *MockConfiguration) UserCodeFormEndpoint() op.Endpoint {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UserCodeFormEndpoint")
-	ret0, _ := ret[0].(op.Endpoint)
-	return ret0
-}
-
-// UserCodeFormEndpoint indicates an expected call of UserCodeFormEndpoint.
-func (mr *MockConfigurationMockRecorder) UserCodeFormEndpoint() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserCodeFormEndpoint", reflect.TypeOf((*MockConfiguration)(nil).UserCodeFormEndpoint))
-}
-
 // UserinfoEndpoint mocks base method.
 func (m *MockConfiguration) UserinfoEndpoint() op.Endpoint {
 	m.ctrl.T.Helper()

--- a/pkg/op/mock/generate.go
+++ b/pkg/op/mock/generate.go
@@ -1,5 +1,6 @@
 package mock
 
+//go:generate go install github.com/golang/mock/mockgen@v1.6.0
 //go:generate mockgen -package mock -destination ./storage.mock.go github.com/zitadel/oidc/v2/pkg/op Storage
 //go:generate mockgen -package mock -destination ./authorizer.mock.go github.com/zitadel/oidc/v2/pkg/op Authorizer
 //go:generate mockgen -package mock -destination ./client.mock.go github.com/zitadel/oidc/v2/pkg/op Client


### PR DESCRIPTION
@muhlemmer 

Here's a fix for that extra stuff in go.mod.   This also auto-install the mock generator and then cleans up go.mod for that too.

Regenerating mocks created a change.   I presume the change is legitimate but if you want, I can revert that change.

See: https://github.com/zitadel/oidc/pull/296#discussion_r1121842434