### PR TITLE
chore: remove unused context in NewOpenIDProvider

### DIFF
--- a/example/server/dynamic/op.go
+++ b/example/server/dynamic/op.go
@@ -125,7 +125,7 @@ func newDynamicOP(ctx context.Context, storage op.Storage, key [32]byte) (*op.Pr
 		//this example has only static texts (in English), so we'll set the here accordingly
 		SupportedUILocales: []language.Tag{language.English},
 	}
-	handler, err := op.NewDynamicOpenIDProvider(ctx, "/", config, storage,
+	handler, err := op.NewDynamicOpenIDProvider("/", config, storage,
 		//we must explicitly allow the use of the http issuer
 		op.WithAllowInsecure(),
 		//as an example on how to customize an endpoint this will change the authorization_endpoint from /authorize to /auth

--- a/example/server/exampleop/op.go
+++ b/example/server/exampleop/op.go
@@ -1,7 +1,6 @@
 package exampleop
 
 import (
-	"context"
 	"crypto/sha256"
 	"log"
 	"net/http"
@@ -35,7 +34,7 @@ type Storage interface {
 // SetupServer creates an OIDC server with Issuer=http://localhost:<port>
 //
 // Use one of the pre-made clients in storage/clients.go or register a new one.
-func SetupServer(ctx context.Context, issuer string, storage Storage) *mux.Router {
+func SetupServer(issuer string, storage Storage) *mux.Router {
 	// the OpenID Provider requires a 32-byte key for (token) encryption
 	// be sure to create a proper crypto random key and manage it securely!
 	key := sha256.Sum256([]byte("test"))
@@ -51,7 +50,7 @@ func SetupServer(ctx context.Context, issuer string, storage Storage) *mux.Route
 	})
 
 	// creation of the OpenIDProvider with the just created in-memory Storage
-	provider, err := newOP(ctx, storage, issuer, key)
+	provider, err := newOP(storage, issuer, key)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +79,7 @@ func SetupServer(ctx context.Context, issuer string, storage Storage) *mux.Route
 // newOP will create an OpenID Provider for localhost on a specified port with a given encryption key
 // and a predefined default logout uri
 // it will enable all options (see descriptions)
-func newOP(ctx context.Context, storage op.Storage, issuer string, key [32]byte) (op.OpenIDProvider, error) {
+func newOP(storage op.Storage, issuer string, key [32]byte) (op.OpenIDProvider, error) {
 	config := &op.Config{
 		CryptoKey: key,
 
@@ -112,7 +111,7 @@ func newOP(ctx context.Context, storage op.Storage, issuer string, key [32]byte)
 			UserCode:     op.UserCodeBase20,
 		},
 	}
-	handler, err := op.NewOpenIDProvider(ctx, issuer, config, storage,
+	handler, err := op.NewOpenIDProvider(issuer, config, storage,
 		//we must explicitly allow the use of the http issuer
 		op.WithAllowInsecure(),
 		// as an example on how to customize an endpoint this will change the authorization_endpoint from /authorize to /auth

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,8 +10,6 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
-
 	//we will run on :9998
 	port := "9998"
 	//which gives us the issuer: http://localhost:9998/
@@ -23,7 +20,7 @@ func main() {
 	// in this example it will be handled in-memory
 	storage := storage.NewStorage(storage.NewUserStore(issuer))
 
-	router := exampleop.SetupServer(ctx, issuer, storage)
+	router := exampleop.SetupServer(issuer, storage)
 
 	server := &http.Server{
 		Addr:    ":" + port,
@@ -35,5 +32,4 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	<-ctx.Done()
 }

--- a/pkg/client/integration_test.go
+++ b/pkg/client/integration_test.go
@@ -2,7 +2,6 @@ package client_test
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -30,14 +29,13 @@ import (
 
 func TestRelyingPartySession(t *testing.T) {
 	t.Log("------- start example OP ------")
-	ctx := context.Background()
 	targetURL := "http://local-site"
 	exampleStorage := storage.NewStorage(storage.NewUserStore(targetURL))
 	var dh deferredHandler
 	opServer := httptest.NewServer(&dh)
 	defer opServer.Close()
 	t.Logf("auth server at %s", opServer.URL)
-	dh.Handler = exampleop.SetupServer(ctx, opServer.URL, exampleStorage)
+	dh.Handler = exampleop.SetupServer(opServer.URL, exampleStorage)
 
 	seed := rand.New(rand.NewSource(int64(os.Getpid()) + time.Now().UnixNano()))
 	clientID := t.Name() + "-" + strconv.FormatInt(seed.Int63(), 25)
@@ -79,14 +77,13 @@ func TestRelyingPartySession(t *testing.T) {
 
 func TestResourceServerTokenExchange(t *testing.T) {
 	t.Log("------- start example OP ------")
-	ctx := context.Background()
 	targetURL := "http://local-site"
 	exampleStorage := storage.NewStorage(storage.NewUserStore(targetURL))
 	var dh deferredHandler
 	opServer := httptest.NewServer(&dh)
 	defer opServer.Close()
 	t.Logf("auth server at %s", opServer.URL)
-	dh.Handler = exampleop.SetupServer(ctx, opServer.URL, exampleStorage)
+	dh.Handler = exampleop.SetupServer(opServer.URL, exampleStorage)
 
 	seed := rand.New(rand.NewSource(int64(os.Getpid()) + time.Now().UnixNano()))
 	clientID := t.Name() + "-" + strconv.FormatInt(seed.Int63(), 25)

--- a/pkg/op/device_test.go
+++ b/pkg/op/device_test.go
@@ -54,7 +54,7 @@ func init() {
 	)
 
 	var err error
-	testProvider, err = op.NewOpenIDProvider(context.TODO(), testIssuer, config,
+	testProvider, err = op.NewOpenIDProvider(testIssuer, config,
 		storage.NewStorage(storage.NewUserStore(testIssuer)), op.WithAllowInsecure(),
 	)
 	if err != nil {

--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -157,15 +157,15 @@ type endpoints struct {
 // Successful logins should mark the request as authorized and redirect back to to
 // op.AuthCallbackURL(provider) which is probably /callback. On the redirect back
 // to the AuthCallbackURL, the request id should be passed as the "id" parameter.
-func NewOpenIDProvider(ctx context.Context, issuer string, config *Config, storage Storage, opOpts ...Option) (*Provider, error) {
-	return newProvider(ctx, config, storage, StaticIssuer(issuer), opOpts...)
+func NewOpenIDProvider(issuer string, config *Config, storage Storage, opOpts ...Option) (*Provider, error) {
+	return newProvider(config, storage, StaticIssuer(issuer), opOpts...)
 }
 
-func NewDynamicOpenIDProvider(ctx context.Context, path string, config *Config, storage Storage, opOpts ...Option) (*Provider, error) {
-	return newProvider(ctx, config, storage, IssuerFromHost(path), opOpts...)
+func NewDynamicOpenIDProvider(path string, config *Config, storage Storage, opOpts ...Option) (*Provider, error) {
+	return newProvider(config, storage, IssuerFromHost(path), opOpts...)
 }
 
-func newProvider(ctx context.Context, config *Config, storage Storage, issuer func(bool) (IssuerFromRequest, error), opOpts ...Option) (_ *Provider, err error) {
+func newProvider(config *Config, storage Storage, issuer func(bool) (IssuerFromRequest, error), opOpts ...Option) (_ *Provider, err error) {
 	o := &Provider{
 		config:    config,
 		storage:   storage,


### PR DESCRIPTION
BREAKING CHANGE:

- op.NewOpenIDProvider
- op.NewDynamicOpenIDProvider

The call chain of above functions did not use the context anywhere.
This change removes the context from those fucntion arguments.