### PR TITLE
feat: add CanSetUserinfoFromRequest interface

### DIFF
--- a/example/server/storage/storage.go
+++ b/example/server/storage/storage.go
@@ -360,6 +360,12 @@ func (s *Storage) SetUserinfoFromScopes(ctx context.Context, userinfo oidc.UserI
 	return s.setUserinfo(ctx, userinfo, userID, clientID, scopes)
 }
 
+// SetUserinfoFromRequest is an optional addon to op.Storage for setting user information
+// using the request.
+func (s *Storage) SetUserinfoFromRequest(ctx context.Context, userinfo oidc.UserInfoSetter, request op.IDTokenRequest, scopes []string) error {
+	return nil
+}
+
 // SetUserinfoFromToken implements the op.Storage interface
 // it will be called for the userinfo endpoint, so we read the token and pass the information from that to the private function
 func (s *Storage) SetUserinfoFromToken(ctx context.Context, userinfo oidc.UserInfoSetter, tokenID, subject, origin string) error {

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -82,6 +82,13 @@ type OPStorage interface {
 	ValidateJWTProfileScopes(ctx context.Context, userID string, scopes []string) ([]string, error)
 }
 
+// CanSetUserinfoFromRequest is an optional additional interface that may be implemented by
+// implementors of Storage.  It allows additional data to be set in id_tokens based on the
+// request.
+type CanSetUserinfoFromRequest interface {
+	SetUserinfoFromRequest(ctx context.Context, userinfo oidc.UserInfoSetter, request IDTokenRequest, scopes []string) error
+}
+
 // Storage is a required parameter for NewOpenIDProvider(). In addition to the
 // embedded interfaces below, if the passed Storage implements ClientCredentialsStorage
 // then the grant type "client_credentials" will be supported. In that case, the access

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -145,6 +145,12 @@ func CreateIDToken(ctx context.Context, issuer string, request IDTokenRequest, v
 		if err != nil {
 			return "", err
 		}
+		if fromRequest, ok := storage.(CanSetUserinfoFromRequest); ok {
+			err := fromRequest.SetUserinfoFromRequest(ctx, userInfo, request, scopes)
+			if err != nil {
+				return "", err
+			}
+		}
 		claims.SetUserinfo(userInfo)
 	}
 	if code != "" {


### PR DESCRIPTION
To support adding session-related claims (like a session id) to IDTokens, I've added a new (optional) add-on interface to Storage:

```go
// CanSetUserinfoFromRequest is an optional additional interface that may be implemented by
// implementors of Storage.  It allows additional data to be set in id_tokens based on the
// request.
type CanSetUserinfoFromRequest interface {
	SetUserinfoFromRequest(ctx context.Context, userinfo oidc.UserInfoSetter, request IDTokenRequest, scopes []string) error
}
```

For the `next` branch, we can simply add `request IDTokenRequest` as an additional parameter to `SetUserinfoFromScopes`