### PR TITLE
chore: document non-standard glob client

### DIFF
--- a/example/server/storage/client.go
+++ b/example/server/storage/client.go
@@ -32,6 +32,8 @@ type Client struct {
 	devMode                        bool
 	idTokenUserinfoClaimsAssertion bool
 	clockSkew                      time.Duration
+	postLogoutRedirectURIGlobs     []string
+	redirectURIGlobs               []string
 }
 
 // GetID must return the client_id
@@ -44,19 +46,9 @@ func (c *Client) RedirectURIs() []string {
 	return c.redirectURIs
 }
 
-// RedirectURIGlobs provide wildcarding for additional valid redirects
-func (c *Client) RedirectURIGlobs() []string {
-	return nil
-}
-
 // PostLogoutRedirectURIs must return the registered post_logout_redirect_uris for sign-outs
 func (c *Client) PostLogoutRedirectURIs() []string {
 	return []string{}
-}
-
-// PostLogoutRedirectURIGlobs provide extra wildcarding for additional valid redirects
-func (c *Client) PostLogoutRedirectURIGlobs() []string {
-	return nil
 }
 
 // ApplicationType must return the type of the client (app, native, user agent)
@@ -199,4 +191,27 @@ func WebClient(id, secret string, redirectURIs ...string) *Client {
 		idTokenUserinfoClaimsAssertion: false,
 		clockSkew:                      0,
 	}
+}
+
+type hasRedirectGlobs struct {
+	*Client
+}
+
+// RedirectURIGlobs provide wildcarding for additional valid redirects
+func (c hasRedirectGlobs) RedirectURIGlobs() []string {
+	return c.redirectURIGlobs
+}
+
+// PostLogoutRedirectURIGlobs provide extra wildcarding for additional valid redirects
+func (c hasRedirectGlobs) PostLogoutRedirectURIGlobs() []string {
+	return c.postLogoutRedirectURIGlobs
+}
+
+// RedirectGlobsClient wraps the client in a op.HasRedirectGlobs
+// only if DevMode is enabled.
+func RedirectGlobsClient(client *Client) op.Client {
+	if client.devMode {
+		return hasRedirectGlobs{client}
+	}
+	return client
 }

--- a/example/server/storage/storage.go
+++ b/example/server/storage/storage.go
@@ -418,7 +418,7 @@ func (s *Storage) GetClientByClientID(ctx context.Context, clientID string) (op.
 	if !ok {
 		return nil, fmt.Errorf("client not found")
 	}
-	return client, nil
+	return RedirectGlobsClient(client), nil
 }
 
 // AuthorizeClientIDSecret implements the op.Storage interface

--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -274,9 +274,9 @@ func ValidateAuthReqScopes(client Client, scopes []string) ([]string, error) {
 	return scopes, nil
 }
 
-// checkURIAginstRedirects just checks aginst the valid redirect URIs and ignores
+// checkURIAgainstRedirects just checks aginst the valid redirect URIs and ignores
 // other factors.
-func checkURIAginstRedirects(client Client, uri string) error {
+func checkURIAgainstRedirects(client Client, uri string) error {
 	if str.Contains(client.RedirectURIs(), uri) {
 		return nil
 	}
@@ -303,12 +303,12 @@ func ValidateAuthReqRedirectURI(client Client, uri string, responseType oidc.Res
 			"Please ensure it is added to the request. If you have any questions, you may contact the administrator of the application.")
 	}
 	if strings.HasPrefix(uri, "https://") {
-		return checkURIAginstRedirects(client, uri)
+		return checkURIAgainstRedirects(client, uri)
 	}
 	if client.ApplicationType() == ApplicationTypeNative {
 		return validateAuthReqRedirectURINative(client, uri, responseType)
 	}
-	if err := checkURIAginstRedirects(client, uri); err != nil {
+	if err := checkURIAgainstRedirects(client, uri); err != nil {
 		return err
 	}
 	if strings.HasPrefix(uri, "http://") {
@@ -329,7 +329,7 @@ func ValidateAuthReqRedirectURI(client Client, uri string, responseType oidc.Res
 func validateAuthReqRedirectURINative(client Client, uri string, responseType oidc.ResponseType) error {
 	parsedURL, isLoopback := HTTPLoopbackOrLocalhost(uri)
 	isCustomSchema := !strings.HasPrefix(uri, "http://")
-	if err := checkURIAginstRedirects(client, uri); err == nil {
+	if err := checkURIAgainstRedirects(client, uri); err == nil {
 		if client.DevMode() {
 			return nil
 		}

--- a/pkg/op/client.go
+++ b/pkg/op/client.go
@@ -57,7 +57,7 @@ type Client interface {
 // glob version will be accepted. Glob URIs are only partially supported for native
 // clients: "http://" is not allowed except for loopback or in dev mode.
 //
-// Note that globbing / wildcards are not permitted by the oidc
+// Note that globbing / wildcards are not permitted by the OIDC
 // standard and implementing this interface can have security implications.
 // It is advised to only return a client of this type in rare cases,
 // such as DevMode for the client being enabled.

--- a/pkg/op/client.go
+++ b/pkg/op/client.go
@@ -56,6 +56,12 @@ type Client interface {
 // interpretation. Redirect URIs that match either the non-glob version or the
 // glob version will be accepted. Glob URIs are only partially supported for native
 // clients: "http://" is not allowed except for loopback or in dev mode.
+//
+// Note that globbing / wildcards are not permitted by the oidc
+// standard and implementing this interface can have security implications.
+// It is advised to only return a client of this type in rare cases,
+// such as DevMode for the client being enabled.
+// https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 type HasRedirectGlobs interface {
 	RedirectURIGlobs() []string
 	PostLogoutRedirectURIGlobs() []string


### PR DESCRIPTION
Update the docs and example on glob support regarding standard deviation.
Glob pattern matching was introduced as an optional interface in #297 to provide wildcard support.

1. Fix a typo
2. Document standard deviation when using globs.
3. Add example on how to toggle the underlying client implementation based on DevMode.

Open to discussion.

Closes #308 