### PR TITLE
feat: GetUserinfo helper method for IDTokenClaims

### DIFF
--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -159,6 +159,17 @@ func (t *IDTokenClaims) SetUserInfo(i *UserInfo) {
 	t.Address = i.Address
 }
 
+func (t *IDTokenClaims) GetUserInfo() *UserInfo {
+	return &UserInfo{
+		Subject:         t.Subject,
+		UserInfoProfile: t.UserInfoProfile,
+		UserInfoEmail:   t.UserInfoEmail,
+		UserInfoPhone:   t.UserInfoPhone,
+		Address:         t.Address,
+		Claims:          t.Claims,
+	}
+}
+
 func NewIDTokenClaims(issuer, subject string, audience []string, expiration, authTime time.Time, nonce string, acr string, amr []string, clientID string, skew time.Duration) *IDTokenClaims {
 	audience = AppendClientIDToAudience(clientID, audience)
 	return &IDTokenClaims{

--- a/pkg/oidc/token_test.go
+++ b/pkg/oidc/token_test.go
@@ -225,3 +225,8 @@ func TestNewIDTokenClaims(t *testing.T) {
 
 	assert.Equal(t, want, got)
 }
+
+func TestIDTokenClaims_GetUserInfo(t *testing.T) {
+	got := idTokenData.GetUserInfo()
+	assert.Equal(t, userInfoData, got)
+}

--- a/pkg/oidc/token_test.go
+++ b/pkg/oidc/token_test.go
@@ -227,6 +227,14 @@ func TestNewIDTokenClaims(t *testing.T) {
 }
 
 func TestIDTokenClaims_GetUserInfo(t *testing.T) {
+	want := &UserInfo{
+		Subject:         idTokenData.Subject,
+		UserInfoProfile: idTokenData.UserInfoProfile,
+		UserInfoEmail:   idTokenData.UserInfoEmail,
+		UserInfoPhone:   idTokenData.UserInfoPhone,
+		Address:         idTokenData.Address,
+		Claims:          idTokenData.Claims,
+	}
 	got := idTokenData.GetUserInfo()
-	assert.Equal(t, userInfoData, got)
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
https://github.com/zitadel/zitadel/pull/5437 can't build, because IDTokenClaims are no longer an interface matching with UserInfo in v2 of OIDC, on this line:

https://github.com/zitadel/zitadel/blob/f5d0378335ee969021de66ca05da46af020e53ec/internal/idp/providers/oidc/session.go#L50-L52

Instead, the UserInfo must be extracted from IDTokenClaims. This PR provides a Get method to make that process easier.