### PR TITLE
fix: handle the zero cases for oidc.Time

### DIFF
--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -173,10 +173,16 @@ func NewEncoder() *schema.Encoder {
 type Time int64
 
 func (ts Time) AsTime() time.Time {
+	if ts == 0 {
+		return time.Time{}
+	}
 	return time.Unix(int64(ts), 0)
 }
 
 func FromTime(tt time.Time) Time {
+	if tt.IsZero() {
+		return 0
+	}
 	return Time(tt.Unix())
 }
 

--- a/pkg/oidc/types_test.go
+++ b/pkg/oidc/types_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/schema"
 	"github.com/stretchr/testify/assert"
@@ -465,6 +466,56 @@ func TestNewEncoder(t *testing.T) {
 	var b request
 	schema.NewDecoder().Decode(&b, values)
 	assert.Equal(t, a, b)
+}
+
+func TestTime_AsTime(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   Time
+		want time.Time
+	}{
+		{
+			name: "unset",
+			ts:   0,
+			want: time.Time{},
+		},
+		{
+			name: "set",
+			ts:   1,
+			want: time.Unix(1, 0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ts.AsTime()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTime_FromTime(t *testing.T) {
+	tests := []struct {
+		name string
+		tt   time.Time
+		want Time
+	}{
+		{
+			name: "zero",
+			tt:   time.Time{},
+			want: 0,
+		},
+		{
+			name: "set",
+			tt:   time.Unix(1, 0),
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromTime(tt.tt)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestTime_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
When Time fields was not set in JSON, the zero value `0`, resulted in a non-zero `time.Time` in conversion. This made verifier checks against a zero (unset) time always pass:

https://github.com/zitadel/oidc/blob/5a14f8d3e443d4e6a846451924bf993fcb8dd992/pkg/oidc/verifier.go#L179

This bug was most likely introduced in #283 refactorings.

Likewise, passing an empty time to `oidc.FromTime` now results in a `0` value for the JSON.