### PR TITLE
fix: correct returned field for JWTTokenRequest

### DIFF
--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -192,7 +192,7 @@ func (j *JWTTokenRequest) GetExpiration() time.Time {
 
 // GetIssuedAt implements the Claims interface
 func (j *JWTTokenRequest) GetIssuedAt() time.Time {
-	return j.ExpiresAt.AsTime()
+	return j.IssuedAt.AsTime()
 }
 
 // GetNonce implements the Claims interface


### PR DESCRIPTION
JWTTokenRequest.GetIssuedAt() was returning the ExpiresAt field.
This change corrects that by returning IssuedAt instead.

This bug was introduced in #283