### PR TITLE
fix: merge user info claims into id token claims

### DIFF
--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2"
 
+	"github.com/muhlemmer/gu"
 	"github.com/zitadel/oidc/v2/pkg/crypto"
 )
 
@@ -157,6 +158,11 @@ func (t *IDTokenClaims) SetUserInfo(i *UserInfo) {
 	t.UserInfoEmail = i.UserInfoEmail
 	t.UserInfoPhone = i.UserInfoPhone
 	t.Address = i.Address
+
+	if t.Claims == nil {
+		t.Claims = make(map[string]any, len(t.Claims))
+	}
+	gu.MapMerge(i.Claims, t.Claims)
 }
 
 func (t *IDTokenClaims) GetUserInfo() *UserInfo {
@@ -166,7 +172,7 @@ func (t *IDTokenClaims) GetUserInfo() *UserInfo {
 		UserInfoEmail:   t.UserInfoEmail,
 		UserInfoPhone:   t.UserInfoPhone,
 		Address:         t.Address,
-		Claims:          t.Claims,
+		Claims:          gu.MapCopy(t.Claims),
 	}
 }
 

--- a/pkg/oidc/token_test.go
+++ b/pkg/oidc/token_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
 	"gopkg.in/square/go-jose.v2"
@@ -181,6 +182,7 @@ func TestIDTokenClaims_SetUserInfo(t *testing.T) {
 		UserInfoEmail:   userInfoData.UserInfoEmail,
 		UserInfoPhone:   userInfoData.UserInfoPhone,
 		Address:         userInfoData.Address,
+		Claims:          gu.MapCopy(userInfoData.Claims),
 	}
 
 	var got IDTokenClaims


### PR DESCRIPTION
oidc IDTokenClaims.SetUserInfo did not set the claims map from user info.
This fix merges the claims map into the IDToken Claims map.