### PR TITLE
fix: do not modify userInfo when marshaling

### DIFF
--- a/pkg/oidc/introspection_test.go
+++ b/pkg/oidc/introspection_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ func TestIntrospectionResponse_SetUserInfo(t *testing.T) {
 				UserInfoProfile: userInfoData.UserInfoProfile,
 				UserInfoEmail:   userInfoData.UserInfoEmail,
 				UserInfoPhone:   userInfoData.UserInfoPhone,
-				Claims:          userInfoData.Claims,
+				Claims:          gu.MapCopy(userInfoData.Claims),
 			},
 		},
 		{

--- a/pkg/oidc/regression_assert_test.go
+++ b/pkg/oidc/regression_assert_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -38,10 +39,12 @@ func Test_assert_regression(t *testing.T) {
 
 			assert.JSONEq(t, want, first)
 
+			target := reflect.New(reflect.TypeOf(obj).Elem()).Interface()
+
 			require.NoError(t,
-				json.Unmarshal([]byte(first), obj),
+				json.Unmarshal([]byte(first), target),
 			)
-			second, err := json.Marshal(obj)
+			second, err := json.Marshal(target)
 			require.NoError(t, err)
 
 			assert.JSONEq(t, want, string(second))

--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -158,7 +158,6 @@ func (t *IDTokenClaims) SetUserInfo(i *UserInfo) {
 	t.UserInfoEmail = i.UserInfoEmail
 	t.UserInfoPhone = i.UserInfoPhone
 	t.Address = i.Address
-
 	if t.Claims == nil {
 		t.Claims = make(map[string]any, len(t.Claims))
 	}

--- a/pkg/oidc/token_test.go
+++ b/pkg/oidc/token_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
 	"gopkg.in/square/go-jose.v2"
@@ -182,7 +181,9 @@ func TestIDTokenClaims_SetUserInfo(t *testing.T) {
 		UserInfoEmail:   userInfoData.UserInfoEmail,
 		UserInfoPhone:   userInfoData.UserInfoPhone,
 		Address:         userInfoData.Address,
-		Claims:          gu.MapCopy(userInfoData.Claims),
+		Claims: map[string]interface{}{
+			"foo": "bar",
+		},
 	}
 
 	var got IDTokenClaims

--- a/pkg/oidc/userinfo_test.go
+++ b/pkg/oidc/userinfo_test.go
@@ -52,11 +52,14 @@ func TestUserInfoMarshal(t *testing.T) {
 
 	out := new(UserInfo)
 	assert.NoError(t, json.Unmarshal(marshal, out))
-	assert.Equal(t, userinfo, out)
 	expected, err := json.Marshal(out)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expected, marshal)
+
+	out2 := new(UserInfo)
+	assert.NoError(t, json.Unmarshal(expected, out2))
+	assert.Equal(t, out, out2)
 }
 
 func TestUserInfoEmailVerifiedUnmarshal(t *testing.T) {


### PR DESCRIPTION
This somewhat duplicates #349.  I hit the same problem but didn't know it had been fixed.

My fix additionally removes side effects from marshaling tokens.
