### PR TITLE
feat: Allow modifying request to device authorization endpoint

### DIFF
--- a/example/client/device/device.go
+++ b/example/client/device/device.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	logrus.Info("starting device authorization flow")
-	resp, err := rp.DeviceAuthorization(ctx, scopes, provider)
+	resp, err := rp.DeviceAuthorization(ctx, scopes, provider, nil)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -186,8 +186,8 @@ type DeviceAuthorizationCaller interface {
 	HttpClient() *http.Client
 }
 
-func CallDeviceAuthorizationEndpoint(ctx context.Context, request *oidc.ClientCredentialsRequest, caller DeviceAuthorizationCaller) (*oidc.DeviceAuthorizationResponse, error) {
-	req, err := httphelper.FormRequest(ctx, caller.GetDeviceAuthorizationEndpoint(), request, Encoder, nil)
+func CallDeviceAuthorizationEndpoint(ctx context.Context, request *oidc.ClientCredentialsRequest, caller DeviceAuthorizationCaller, authFn any) (*oidc.DeviceAuthorizationResponse, error) {
+	req, err := httphelper.FormRequest(ctx, caller.GetDeviceAuthorizationEndpoint(), request, Encoder, authFn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/rp/device.go
+++ b/pkg/client/rp/device.go
@@ -33,13 +33,13 @@ func newDeviceClientCredentialsRequest(scopes []string, rp RelyingParty) (*oidc.
 // DeviceAuthorization starts a new Device Authorization flow as defined
 // in RFC 8628, section 3.1 and 3.2:
 // https://www.rfc-editor.org/rfc/rfc8628#section-3.1
-func DeviceAuthorization(ctx context.Context, scopes []string, rp RelyingParty) (*oidc.DeviceAuthorizationResponse, error) {
+func DeviceAuthorization(ctx context.Context, scopes []string, rp RelyingParty, authFn any) (*oidc.DeviceAuthorizationResponse, error) {
 	req, err := newDeviceClientCredentialsRequest(scopes, rp)
 	if err != nil {
 		return nil, err
 	}
 
-	return client.CallDeviceAuthorizationEndpoint(ctx, req, rp)
+	return client.CallDeviceAuthorizationEndpoint(ctx, req, rp, authFn)
 }
 
 // DeviceAccessToken attempts to obtain tokens from a Device Authorization,


### PR DESCRIPTION
This change enables the caller to set URL parameters when calling the
device authorization endpoint.

Resolves #354
