### PR TITLE
feat: get issuer from context for device auth

### DIFF
--- a/example/server/exampleop/op.go
+++ b/example/server/exampleop/op.go
@@ -107,7 +107,7 @@ func newOP(storage op.Storage, issuer string, key [32]byte) (op.OpenIDProvider, 
 		DeviceAuthorization: op.DeviceAuthorizationConfig{
 			Lifetime:     5 * time.Minute,
 			PollInterval: 5 * time.Second,
-			UserFormURL:  issuer + "device",
+			UserFormURL:  "/device",
 			UserCode:     op.UserCodeBase20,
 		},
 	}

--- a/example/server/exampleop/op.go
+++ b/example/server/exampleop/op.go
@@ -107,7 +107,7 @@ func newOP(storage op.Storage, issuer string, key [32]byte) (op.OpenIDProvider, 
 		DeviceAuthorization: op.DeviceAuthorizationConfig{
 			Lifetime:     5 * time.Minute,
 			PollInterval: 5 * time.Second,
-			UserFormURL:  "/device",
+			UserFormPath: "/device",
 			UserCode:     op.UserCodeBase20,
 		},
 	}

--- a/pkg/op/device_test.go
+++ b/pkg/op/device_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
@@ -20,30 +21,60 @@ import (
 )
 
 func Test_deviceAuthorizationHandler(t *testing.T) {
-	req := &oidc.DeviceAuthorizationRequest{
-		Scopes:   []string{"foo", "bar"},
-		ClientID: "web",
+	type conf struct {
+		UserFormURL  string
+		UserFormPath string
 	}
-	values := make(url.Values)
-	testProvider.Encoder().Encode(req, values)
-	body := strings.NewReader(values.Encode())
+	tests := []struct {
+		name string
+		conf conf
+	}{
+		{
+			name: "UserFormURL",
+			conf: conf{
+				UserFormURL: "https://localhost:9998/device",
+			},
+		},
+		{
+			name: "UserFormPath",
+			conf: conf{
+				UserFormPath: "/device",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := gu.PtrCopy(testConfig)
+			conf.DeviceAuthorization.UserFormURL = tt.conf.UserFormURL
+			conf.DeviceAuthorization.UserFormPath = tt.conf.UserFormPath
+			provider := newTestProvider(conf)
 
-	r := httptest.NewRequest(http.MethodPost, "/", body)
-	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	r = r.WithContext(op.ContextWithIssuer(r.Context(), testIssuer))
+			req := &oidc.DeviceAuthorizationRequest{
+				Scopes:   []string{"foo", "bar"},
+				ClientID: "web",
+			}
+			values := make(url.Values)
+			testProvider.Encoder().Encode(req, values)
+			body := strings.NewReader(values.Encode())
 
-	w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", body)
+			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			r = r.WithContext(op.ContextWithIssuer(r.Context(), testIssuer))
 
-	runWithRandReader(mr.New(mr.NewSource(1)), func() {
-		op.DeviceAuthorizationHandler(testProvider)(w, r)
-	})
+			w := httptest.NewRecorder()
 
-	result := w.Result()
+			runWithRandReader(mr.New(mr.NewSource(1)), func() {
+				op.DeviceAuthorizationHandler(provider)(w, r)
+			})
 
-	assert.Less(t, result.StatusCode, 300)
+			result := w.Result()
 
-	got, _ := io.ReadAll(result.Body)
-	assert.JSONEq(t, `{"device_code":"Uv38ByGCZU8WP18PmmIdcg", "expires_in":300, "interval":5, "user_code":"JKRV-FRGK", "verification_uri":"https://localhost:9998/device", "verification_uri_complete":"https://localhost:9998/device?user_code=JKRV-FRGK"}`, string(got))
+			assert.Less(t, result.StatusCode, 300)
+
+			got, _ := io.ReadAll(result.Body)
+			assert.JSONEq(t, `{"device_code":"Uv38ByGCZU8WP18PmmIdcg", "expires_in":300, "interval":5, "user_code":"JKRV-FRGK", "verification_uri":"https://localhost:9998/device", "verification_uri_complete":"https://localhost:9998/device?user_code=JKRV-FRGK"}`, string(got))
+		})
+	}
 }
 
 func TestParseDeviceCodeRequest(t *testing.T) {

--- a/pkg/op/device_test.go
+++ b/pkg/op/device_test.go
@@ -30,6 +30,7 @@ func Test_deviceAuthorizationHandler(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodPost, "/", body)
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r = r.WithContext(op.ContextWithIssuer(r.Context(), testIssuer))
 
 	w := httptest.NewRecorder()
 

--- a/pkg/op/op_test.go
+++ b/pkg/op/op_test.go
@@ -40,7 +40,7 @@ func init() {
 		DeviceAuthorization: op.DeviceAuthorizationConfig{
 			Lifetime:     5 * time.Minute,
 			PollInterval: 5 * time.Second,
-			UserFormURL:  testIssuer + "device",
+			UserFormURL:  "/device",
 			UserCode:     op.UserCodeBase20,
 		},
 	}

--- a/pkg/op/op_test.go
+++ b/pkg/op/op_test.go
@@ -20,15 +20,9 @@ import (
 	"golang.org/x/text/language"
 )
 
-var testProvider op.OpenIDProvider
-
-const (
-	testIssuer    = "https://localhost:9998/"
-	pathLoggedOut = "/logged-out"
-)
-
-func init() {
-	config := &op.Config{
+var (
+	testProvider op.OpenIDProvider
+	testConfig   = &op.Config{
 		CryptoKey:                sha256.Sum256([]byte("test")),
 		DefaultLogoutRedirectURI: pathLoggedOut,
 		CodeMethodS256:           true,
@@ -40,24 +34,35 @@ func init() {
 		DeviceAuthorization: op.DeviceAuthorizationConfig{
 			Lifetime:     5 * time.Minute,
 			PollInterval: 5 * time.Second,
-			UserFormURL:  "/device",
+			UserFormPath: "/device",
 			UserCode:     op.UserCodeBase20,
 		},
 	}
+)
 
+const (
+	testIssuer    = "https://localhost:9998/"
+	pathLoggedOut = "/logged-out"
+)
+
+func init() {
 	storage.RegisterClients(
 		storage.NativeClient("native"),
 		storage.WebClient("web", "secret", "https://example.com"),
 		storage.WebClient("api", "secret"),
 	)
 
-	var err error
-	testProvider, err = op.NewOpenIDProvider(testIssuer, config,
+	testProvider = newTestProvider(testConfig)
+}
+
+func newTestProvider(config *op.Config) op.OpenIDProvider {
+	provider, err := op.NewOpenIDProvider(testIssuer, config,
 		storage.NewStorage(storage.NewUserStore(testIssuer)), op.WithAllowInsecure(),
 	)
 	if err != nil {
 		panic(err)
 	}
+	return provider
 }
 
 type routesTestStorage interface {


### PR DESCRIPTION
Device authorization used a static config for the hostname where the user is redirected.
This makes it incompatible with the rest of the framework that uses dynamic issuer.