### PR TITLE
fix: Only set GrantType once (#353)

### DIFF
--- a/pkg/client/rp/device.go
+++ b/pkg/client/rp/device.go
@@ -12,7 +12,6 @@ import (
 func newDeviceClientCredentialsRequest(scopes []string, rp RelyingParty) (*oidc.ClientCredentialsRequest, error) {
 	confg := rp.OAuthConfig()
 	req := &oidc.ClientCredentialsRequest{
-		GrantType:    oidc.GrantTypeDeviceCode,
 		Scope:        scopes,
 		ClientID:     confg.ClientID,
 		ClientSecret: confg.ClientSecret,

--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -241,7 +241,7 @@ type TokenExchangeRequest struct {
 }
 
 type ClientCredentialsRequest struct {
-	GrantType           GrantType           `schema:"grant_type"`
+	GrantType           GrantType           `schema:"grant_type,omitempty"`
 	Scope               SpaceDelimitedArray `schema:"scope"`
 	ClientID            string              `schema:"client_id"`
 	ClientSecret        string              `schema:"client_secret"`


### PR DESCRIPTION
This fixes an issue where, when using the device authorization flow, the
grant type would be set twice. Some OPs don't accept this, and fail when
polling.

With this fix the grant type is only set once, which will make some OPs
happy again.

This fix is in the main branch but is missing in the next branch.

Fixes #352
