### PR TITLE
chore: improve error message when issuer is invalid

### DIFF
--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -325,7 +325,7 @@ func Discover(issuer string, httpClient *http.Client) (Endpoints, error) {
 		return Endpoints{}, err
 	}
 	if discoveryConfig.Issuer != issuer {
-		return Endpoints{}, oidc.ErrIssuerInvalid
+		return Endpoints{}, fmt.Errorf("%w: Expected: %s, got: %s", oidc.ErrIssuerInvalid, discoveryConfig.Issuer, issuer)
 	}
 	return GetEndpoints(discoveryConfig), nil
 }


### PR DESCRIPTION
A tiny change to provide more detail when discovery is rejected due to an issuer mismatch.