### PR TITLE
fix/feature:  prompt=none, response_mode=fragment

### DIFF
--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -569,6 +569,11 @@ func WithPromptURLParam(prompt ...string) URLParamOpt {
 	return withPrompt(prompt...)
 }
 
+// WithResponseModeURLParam sets the `response_mode` parameter in a URL.
+func WithResponseModeURLParam(mode oidc.ResponseMode) URLParamOpt {
+	return withURLParam("response_mode", string(mode))
+}
+
 type AuthURLOpt func() []oauth2.AuthCodeOption
 
 // WithCodeChallenge sets the `code_challenge` params in the auth request

--- a/pkg/oidc/authorization.go
+++ b/pkg/oidc/authorization.go
@@ -60,7 +60,7 @@ const (
 )
 
 // AuthRequest according to:
-//https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+// https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 type AuthRequest struct {
 	Scopes       SpaceDelimitedArray `json:"scope" schema:"scope"`
 	ResponseType ResponseType        `json:"response_type" schema:"response_type"`
@@ -99,4 +99,9 @@ func (a *AuthRequest) GetResponseType() ResponseType {
 // GetState returns the optional state value for the ErrAuthRequest interface
 func (a *AuthRequest) GetState() string {
 	return a.State
+}
+
+// GetResponseMode returns the optional ResponseMode
+func (a *AuthRequest) GetResponseMode() ResponseMode {
+	return a.ResponseMode
 }


### PR DESCRIPTION
Resolves #384 

This changes example op so that an auth request with  `prompt=none` will trigger a login-required error and adds a test that uses `prompt=none` and `respone_mode=fragment`.

feature: rp now support setting the response mode.

fix: `op.AuthRequestError` now honors response mode.  It previously didn't because `oidc.AuthRequest` didn't have a `GetResponseMode()` method.  

tests: additional coverage; exampleop.SetupServer now takes extra server options. 