### PR TITLE
chore: cleanup unneeded device storage methods

### DIFF
--- a/example/server/exampleop/device.go
+++ b/example/server/exampleop/device.go
@@ -1,6 +1,7 @@
 package exampleop
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,18 @@ import (
 type deviceAuthenticate interface {
 	CheckUsernamePasswordSimple(username, password string) error
 	op.DeviceAuthorizationStorage
+
+	// GetDeviceAuthorizationByUserCode resturns the current state of the device authorization flow,
+	// identified by the user code.
+	GetDeviceAuthorizationByUserCode(ctx context.Context, userCode string) (*op.DeviceAuthorizationState, error)
+
+	// CompleteDeviceAuthorization marks a device authorization entry as Completed,
+	// identified by userCode. The Subject is added to the state, so that
+	// GetDeviceAuthorizatonState can use it to create a new Access Token.
+	CompleteDeviceAuthorization(ctx context.Context, userCode, subject string) error
+
+	// DenyDeviceAuthorization marks a device authorization entry as Denied.
+	DenyDeviceAuthorization(ctx context.Context, userCode string) error
 }
 
 type deviceLogin struct {

--- a/pkg/op/device_test.go
+++ b/pkg/op/device_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v3/example/server/storage"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 )
@@ -304,7 +305,7 @@ func BenchmarkNewUserCode(b *testing.B) {
 }
 
 func TestDeviceAccessToken(t *testing.T) {
-	storage := testProvider.Storage().(op.DeviceAuthorizationStorage)
+	storage := testProvider.Storage().(*storage.Storage)
 	storage.StoreDeviceAuthorization(context.Background(), "native", "qwerty", "yuiop", time.Now().Add(time.Minute), []string{"foo"})
 	storage.CompleteDeviceAuthorization(context.Background(), "yuiop", "tim")
 
@@ -329,7 +330,7 @@ func TestDeviceAccessToken(t *testing.T) {
 func TestCheckDeviceAuthorizationState(t *testing.T) {
 	now := time.Now()
 
-	storage := testProvider.Storage().(op.DeviceAuthorizationStorage)
+	storage := testProvider.Storage().(*storage.Storage)
 	storage.StoreDeviceAuthorization(context.Background(), "native", "pending", "pending", now.Add(time.Minute), []string{"foo"})
 	storage.StoreDeviceAuthorization(context.Background(), "native", "denied", "denied", now.Add(time.Minute), []string{"foo"})
 	storage.StoreDeviceAuthorization(context.Background(), "native", "completed", "completed", now.Add(time.Minute), []string{"foo"})

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -182,18 +182,6 @@ type DeviceAuthorizationStorage interface {
 	// GetDeviceAuthorizatonState returns the current state of the device authorization flow in the database.
 	// The method is polled untill the the authorization is eighter Completed, Expired or Denied.
 	GetDeviceAuthorizatonState(ctx context.Context, clientID, deviceCode string) (*DeviceAuthorizationState, error)
-
-	// GetDeviceAuthorizationByUserCode resturn the current state of the device authorization flow,
-	// identified by the user code.
-	GetDeviceAuthorizationByUserCode(ctx context.Context, userCode string) (*DeviceAuthorizationState, error)
-
-	// CompleteDeviceAuthorization marks a device authorization entry as Completed,
-	// identified by userCode. The Subject is added to the state, so that
-	// GetDeviceAuthorizatonState can use it to create a new Access Token.
-	CompleteDeviceAuthorization(ctx context.Context, userCode, subject string) error
-
-	// DenyDeviceAuthorization marks a device authorization entry as Denied.
-	DenyDeviceAuthorization(ctx context.Context, userCode string) error
 }
 
 func assertDeviceStorage(s Storage) (DeviceAuthorizationStorage, error) {


### PR DESCRIPTION
BREAKING CHANGE, removes methods from DeviceAuthorizationStorage:

- GetDeviceAuthorizationByUserCode
- CompleteDeviceAuthorization
- DenyDeviceAuthorization

The methods are now moved to examples as something similar can be
userful for implementers.

Closes #371