### PR TITLE
fix: don't error on invalid i18n tags in discovery

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscover(t *testing.T) {
+	type wantFields struct {
+		UILocalesSupported bool
+	}
+
+	type args struct {
+		issuer       string
+		wellKnownUrl []string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantFields *wantFields
+		wantErr    bool
+	}{
+		{
+			name: "spotify", // https://github.com/zitadel/oidc/issues/406
+			args: args{
+				issuer: "https://accounts.spotify.com",
+			},
+			wantFields: &wantFields{
+				UILocalesSupported: true,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Discover(tt.args.issuer, http.DefaultClient, tt.args.wellKnownUrl...)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantFields == nil {
+				return
+			}
+			assert.Equal(t, tt.args.issuer, got.Issuer)
+			if tt.wantFields.UILocalesSupported {
+				assert.NotEmpty(t, got.UILocalesSupported)
+			}
+		})
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -31,7 +31,7 @@ func TestDiscover(t *testing.T) {
 			wantFields: &wantFields{
 				UILocalesSupported: true,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -1,9 +1,5 @@
 package oidc
 
-import (
-	"golang.org/x/text/language"
-)
-
 const (
 	DiscoveryEndpoint = "/.well-known/openid-configuration"
 )
@@ -130,10 +126,10 @@ type DiscoveryConfiguration struct {
 	ServiceDocumentation string `json:"service_documentation,omitempty"`
 
 	// ClaimsLocalesSupported contains a list of BCP47 language tag values that the OP supports for values of Claims returned.
-	ClaimsLocalesSupported []language.Tag `json:"claims_locales_supported,omitempty"`
+	ClaimsLocalesSupported Locales `json:"claims_locales_supported,omitempty"`
 
 	// UILocalesSupported contains a list of BCP47 language tag values that the OP supports for the user interface.
-	UILocalesSupported []language.Tag `json:"ui_locales_supported,omitempty"`
+	UILocalesSupported Locales `json:"ui_locales_supported,omitempty"`
 
 	// RequestParameterSupported specifies whether the OP supports use of the `request` parameter. If omitted, the default value is false.
 	RequestParameterSupported bool `json:"request_parameter_supported,omitempty"`


### PR DESCRIPTION
This changes the use of `[]language.Tag` to `oidc.Locales` in `DiscoveryConfig`. This should be compatible with callers that use the `[]language.Tag` .

Locales now implements the `json.Unmarshaler` interface. With support for json arrays or space seperated strings. The latter because `UnmarshalText` might have been implicitly called by the json library before we added `UnmarshalJSON`.

Fixes: #406

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] ~~Where possible E2E tests are implemented~~
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] ~~Functionality of the acceptance criteria is checked manually on the dev system.~~

