### PR TITLE
feat: delete PKCE cookie after code exchange

### DIFF
--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -438,6 +438,7 @@ func CodeExchangeHandler[C oidc.IDClaims](callback CodeExchangeCallback[C], rp R
 				return
 			}
 			codeOpts = append(codeOpts, WithCodeVerifier(codeVerifier))
+			rp.CookieHandler().DeleteCookie(w, pkceCode)
 		}
 		if rp.Signer() != nil {
 			assertion, err := client.SignedJWTProfileAssertion(rp.OAuthConfig().ClientID, []string{rp.Issuer()}, time.Hour, rp.Signer())


### PR DESCRIPTION
Perhaps it would be better to delete the PKCE cookie once the code exchange has been successfully completed?
It's just a line of code but if I missed something of the big picture, feel free to close this PR.