### PR TITLE
fix(op): check if getTokenIDAndClaims succeeded

### DIFF
--- a/pkg/op/token_exchange.go
+++ b/pkg/op/token_exchange.go
@@ -282,6 +282,9 @@ func GetTokenIDAndSubjectFromToken(
 	case oidc.AccessTokenType:
 		var accessTokenClaims *oidc.AccessTokenClaims
 		tokenIDOrToken, subject, accessTokenClaims, ok = getTokenIDAndClaims(ctx, exchanger, token)
+		if !ok {
+			break
+		}
 		claims = accessTokenClaims.Claims
 	case oidc.RefreshTokenType:
 		refreshTokenRequest, err := exchanger.Storage().TokenRequestByRefreshToken(ctx, token)


### PR DESCRIPTION
When getTokenIDAndClaims didn't succeed,
so `ok` would be false.
This was ignored and the accessTokenClaims.Claims call would panic.

Closes #316

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

