### PR TITLE
chore: replace `interface{}` with `any`

### DIFF
--- a/example/client/service/service.go
+++ b/example/client/service/service.go
@@ -125,7 +125,7 @@ func main() {
 		testURL := r.Form.Get("url")
 		var data struct {
 			URL      string
-			Response interface{}
+			Response any
 		}
 		if testURL != "" {
 			data.URL = testURL
@@ -149,7 +149,7 @@ func main() {
 	logrus.Fatal(http.ListenAndServe("127.0.0.1:"+port, nil))
 }
 
-func callExampleEndpoint(client *http.Client, testURL string) (interface{}, error) {
+func callExampleEndpoint(client *http.Client, testURL string) (any, error) {
 	req, err := http.NewRequest("GET", testURL, nil)
 	if err != nil {
 		return nil, err

--- a/example/server/storage/storage.go
+++ b/example/server/storage/storage.go
@@ -61,7 +61,7 @@ func (s *signingKey) SignatureAlgorithm() jose.SignatureAlgorithm {
 	return s.algorithm
 }
 
-func (s *signingKey) Key() interface{} {
+func (s *signingKey) Key() any {
 	return s.key
 }
 
@@ -85,7 +85,7 @@ func (s *publicKey) Use() string {
 	return "sig"
 }
 
-func (s *publicKey) Key() interface{} {
+func (s *publicKey) Key() any {
 	return &s.key.PublicKey
 }
 
@@ -525,11 +525,11 @@ func (s *Storage) SetIntrospectionFromToken(ctx context.Context, introspection *
 
 // GetPrivateClaimsFromScopes implements the op.Storage interface
 // it will be called for the creation of a JWT access token to assert claims for custom scopes
-func (s *Storage) GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (claims map[string]interface{}, err error) {
+func (s *Storage) GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (claims map[string]any, err error) {
 	return s.getPrivateClaimsFromScopes(ctx, userID, clientID, scopes)
 }
 
-func (s *Storage) getPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (claims map[string]interface{}, err error) {
+func (s *Storage) getPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (claims map[string]any, err error) {
 	for _, scope := range scopes {
 		switch scope {
 		case CustomScope:
@@ -713,7 +713,7 @@ func (s *Storage) CreateTokenExchangeRequest(ctx context.Context, request op.Tok
 // GetPrivateClaimsFromScopesForTokenExchange implements the op.TokenExchangeStorage interface
 // it will be called for the creation of an exchanged JWT access token to assert claims for custom scopes
 // plus adding token exchange specific claims related to delegation or impersonation
-func (s *Storage) GetPrivateClaimsFromTokenExchangeRequest(ctx context.Context, request op.TokenExchangeRequest) (claims map[string]interface{}, err error) {
+func (s *Storage) GetPrivateClaimsFromTokenExchangeRequest(ctx context.Context, request op.TokenExchangeRequest) (claims map[string]any, err error) {
 	claims, err = s.getPrivateClaimsFromScopes(ctx, "", request.GetClientID(), request.GetScopes())
 	if err != nil {
 		return nil, err
@@ -742,12 +742,12 @@ func (s *Storage) SetUserinfoFromTokenExchangeRequest(ctx context.Context, useri
 	return nil
 }
 
-func (s *Storage) getTokenExchangeClaims(ctx context.Context, request op.TokenExchangeRequest) (claims map[string]interface{}) {
+func (s *Storage) getTokenExchangeClaims(ctx context.Context, request op.TokenExchangeRequest) (claims map[string]any) {
 	for _, scope := range request.GetScopes() {
 		switch {
 		case strings.HasPrefix(scope, CustomScopeImpersonatePrefix) && request.GetExchangeActor() == "":
 			// Set actor subject claim for impersonation flow
-			claims = appendClaim(claims, "act", map[string]interface{}{
+			claims = appendClaim(claims, "act", map[string]any{
 				"sub": request.GetExchangeSubject(),
 			})
 		}
@@ -755,7 +755,7 @@ func (s *Storage) getTokenExchangeClaims(ctx context.Context, request op.TokenEx
 
 	// Set actor subject claim for delegation flow
 	// if request.GetExchangeActor() != "" {
-	// 	claims = appendClaim(claims, "act", map[string]interface{}{
+	// 	claims = appendClaim(claims, "act", map[string]any{
 	// 		"sub": request.GetExchangeActor(),
 	// 	})
 	// }
@@ -777,16 +777,16 @@ func getInfoFromRequest(req op.TokenRequest) (clientID string, authTime time.Tim
 }
 
 // customClaim demonstrates how to return custom claims based on provided information
-func customClaim(clientID string) map[string]interface{} {
-	return map[string]interface{}{
+func customClaim(clientID string) map[string]any {
+	return map[string]any{
 		"client": clientID,
 		"other":  "stuff",
 	}
 }
 
-func appendClaim(claims map[string]interface{}, claim string, value interface{}) map[string]interface{} {
+func appendClaim(claims map[string]any, claim string, value any) map[string]any {
 	if claims == nil {
-		claims = make(map[string]interface{})
+		claims = make(map[string]any)
 	}
 	claims[claim] = value
 	return claims

--- a/example/server/storage/storage_dynamic.go
+++ b/example/server/storage/storage_dynamic.go
@@ -239,7 +239,7 @@ func (s *multiStorage) SetIntrospectionFromToken(ctx context.Context, introspect
 
 // GetPrivateClaimsFromScopes implements the op.Storage interface
 // it will be called for the creation of a JWT access token to assert claims for custom scopes
-func (s *multiStorage) GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (claims map[string]interface{}, err error) {
+func (s *multiStorage) GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (claims map[string]any, err error) {
 	storage, err := s.storageFromContext(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,11 +48,11 @@ type TokenEndpointCaller interface {
 	HttpClient() *http.Client
 }
 
-func CallTokenEndpoint(request interface{}, caller TokenEndpointCaller) (newToken *oauth2.Token, err error) {
+func CallTokenEndpoint(request any, caller TokenEndpointCaller) (newToken *oauth2.Token, err error) {
 	return callTokenEndpoint(request, nil, caller)
 }
 
-func callTokenEndpoint(request interface{}, authFn interface{}, caller TokenEndpointCaller) (newToken *oauth2.Token, err error) {
+func callTokenEndpoint(request any, authFn any, caller TokenEndpointCaller) (newToken *oauth2.Token, err error) {
 	req, err := httphelper.FormRequest(caller.TokenEndpoint(), request, Encoder, authFn)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ type EndSessionCaller interface {
 	HttpClient() *http.Client
 }
 
-func CallEndSessionEndpoint(request interface{}, authFn interface{}, caller EndSessionCaller) (*url.URL, error) {
+func CallEndSessionEndpoint(request any, authFn any, caller EndSessionCaller) (*url.URL, error) {
 	req, err := httphelper.FormRequest(caller.GetEndSessionEndpoint(), request, Encoder, authFn)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ type RevokeRequest struct {
 	ClientSecret  string `schema:"client_secret"`
 }
 
-func CallRevokeEndpoint(request interface{}, authFn interface{}, caller RevokeCaller) error {
+func CallRevokeEndpoint(request any, authFn any, caller RevokeCaller) error {
 	req, err := httphelper.FormRequest(caller.GetRevokeEndpoint(), request, Encoder, authFn)
 	if err != nil {
 		return err
@@ -151,7 +151,7 @@ func CallRevokeEndpoint(request interface{}, authFn interface{}, caller RevokeCa
 	return nil
 }
 
-func CallTokenExchangeEndpoint(request interface{}, authFn interface{}, caller TokenEndpointCaller) (resp *oidc.TokenExchangeResponse, err error) {
+func CallTokenExchangeEndpoint(request any, authFn any, caller TokenEndpointCaller) (resp *oidc.TokenExchangeResponse, err error) {
 	req, err := httphelper.FormRequest(caller.TokenEndpoint(), request, Encoder, authFn)
 	if err != nil {
 		return nil, err

--- a/pkg/client/rs/resource_server.go
+++ b/pkg/client/rs/resource_server.go
@@ -15,7 +15,7 @@ type ResourceServer interface {
 	IntrospectionURL() string
 	TokenEndpoint() string
 	HttpClient() *http.Client
-	AuthFn() (interface{}, error)
+	AuthFn() (any, error)
 }
 
 type resourceServer struct {
@@ -23,7 +23,7 @@ type resourceServer struct {
 	tokenURL      string
 	introspectURL string
 	httpClient    *http.Client
-	authFn        func() (interface{}, error)
+	authFn        func() (any, error)
 }
 
 func (r *resourceServer) IntrospectionURL() string {
@@ -38,12 +38,12 @@ func (r *resourceServer) HttpClient() *http.Client {
 	return r.httpClient
 }
 
-func (r *resourceServer) AuthFn() (interface{}, error) {
+func (r *resourceServer) AuthFn() (any, error) {
 	return r.authFn()
 }
 
 func NewResourceServerClientCredentials(issuer, clientID, clientSecret string, option ...Option) (ResourceServer, error) {
-	authorizer := func() (interface{}, error) {
+	authorizer := func() (any, error) {
 		return httphelper.AuthorizeBasic(clientID, clientSecret), nil
 	}
 	return newResourceServer(issuer, authorizer, option...)
@@ -54,7 +54,7 @@ func NewResourceServerJWTProfile(issuer, clientID, keyID string, key []byte, opt
 	if err != nil {
 		return nil, err
 	}
-	authorizer := func() (interface{}, error) {
+	authorizer := func() (any, error) {
 		assertion, err := client.SignedJWTProfileAssertion(clientID, []string{issuer}, time.Hour, signer)
 		if err != nil {
 			return nil, err
@@ -64,7 +64,7 @@ func NewResourceServerJWTProfile(issuer, clientID, keyID string, key []byte, opt
 	return newResourceServer(issuer, authorizer, options...)
 }
 
-func newResourceServer(issuer string, authorizer func() (interface{}, error), options ...Option) (*resourceServer, error) {
+func newResourceServer(issuer string, authorizer func() (any, error), options ...Option) (*resourceServer, error) {
 	rs := &resourceServer{
 		issuer:     issuer,
 		httpClient: httphelper.DefaultHTTPClient,

--- a/pkg/client/rs/resource_server_test.go
+++ b/pkg/client/rs/resource_server_test.go
@@ -11,14 +11,14 @@ import (
 func TestNewResourceServer(t *testing.T) {
 	type args struct {
 		issuer     string
-		authorizer func() (interface{}, error)
+		authorizer func() (any, error)
 		options    []Option
 	}
 	type wantFields struct {
 		issuer        string
 		tokenURL      string
 		introspectURL string
-		authFn        func() (interface{}, error)
+		authFn        func() (any, error)
 	}
 	tests := []struct {
 		name       string

--- a/pkg/client/tokenexchange/tokenexchange.go
+++ b/pkg/client/tokenexchange/tokenexchange.go
@@ -12,13 +12,13 @@ import (
 type TokenExchanger interface {
 	TokenEndpoint() string
 	HttpClient() *http.Client
-	AuthFn() (interface{}, error)
+	AuthFn() (any, error)
 }
 
 type OAuthTokenExchange struct {
 	httpClient    *http.Client
 	tokenEndpoint string
-	authFn        func() (interface{}, error)
+	authFn        func() (any, error)
 }
 
 func NewTokenExchanger(issuer string, options ...func(source *OAuthTokenExchange)) (TokenExchanger, error) {
@@ -26,13 +26,13 @@ func NewTokenExchanger(issuer string, options ...func(source *OAuthTokenExchange
 }
 
 func NewTokenExchangerClientCredentials(issuer, clientID, clientSecret string, options ...func(source *OAuthTokenExchange)) (TokenExchanger, error) {
-	authorizer := func() (interface{}, error) {
+	authorizer := func() (any, error) {
 		return httphelper.AuthorizeBasic(clientID, clientSecret), nil
 	}
 	return newOAuthTokenExchange(issuer, authorizer, options...)
 }
 
-func newOAuthTokenExchange(issuer string, authorizer func() (interface{}, error), options ...func(source *OAuthTokenExchange)) (*OAuthTokenExchange, error) {
+func newOAuthTokenExchange(issuer string, authorizer func() (any, error), options ...func(source *OAuthTokenExchange)) (*OAuthTokenExchange, error) {
 	te := &OAuthTokenExchange{
 		httpClient: httphelper.DefaultHTTPClient,
 	}
@@ -78,7 +78,7 @@ func (te *OAuthTokenExchange) HttpClient() *http.Client {
 	return te.httpClient
 }
 
-func (te *OAuthTokenExchange) AuthFn() (interface{}, error) {
+func (te *OAuthTokenExchange) AuthFn() (any, error) {
 	if te.authFn != nil {
 		return te.authFn()
 	}

--- a/pkg/crypto/sign.go
+++ b/pkg/crypto/sign.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-func Sign(object interface{}, signer jose.Signer) (string, error) {
+func Sign(object any, signer jose.Signer) (string, error) {
 	payload, err := json.Marshal(object)
 	if err != nil {
 		return "", err

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -17,11 +17,11 @@ var DefaultHTTPClient = &http.Client{
 }
 
 type Decoder interface {
-	Decode(dst interface{}, src map[string][]string) error
+	Decode(dst any, src map[string][]string) error
 }
 
 type Encoder interface {
-	Encode(src interface{}, dst map[string][]string) error
+	Encode(src any, dst map[string][]string) error
 }
 
 type FormAuthorization func(url.Values)
@@ -33,7 +33,7 @@ func AuthorizeBasic(user, password string) RequestAuthorization {
 	}
 }
 
-func FormRequest(endpoint string, request interface{}, encoder Encoder, authFn interface{}) (*http.Request, error) {
+func FormRequest(endpoint string, request any, encoder Encoder, authFn any) (*http.Request, error) {
 	form := url.Values{}
 	if err := encoder.Encode(request, form); err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func FormRequest(endpoint string, request interface{}, encoder Encoder, authFn i
 	return req, nil
 }
 
-func HttpRequest(client *http.Client, req *http.Request, response interface{}) error {
+func HttpRequest(client *http.Client, req *http.Request, response any) error {
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func HttpRequest(client *http.Client, req *http.Request, response interface{}) e
 	return nil
 }
 
-func URLEncodeParams(resp interface{}, encoder Encoder) (url.Values, error) {
+func URLEncodeParams(resp any, encoder Encoder) (url.Values, error) {
 	values := make(map[string][]string)
 	err := encoder.Encode(resp, values)
 	if err != nil {

--- a/pkg/http/marshal.go
+++ b/pkg/http/marshal.go
@@ -8,11 +8,11 @@ import (
 	"reflect"
 )
 
-func MarshalJSON(w http.ResponseWriter, i interface{}) {
+func MarshalJSON(w http.ResponseWriter, i any) {
 	MarshalJSONWithStatus(w, i, http.StatusOK)
 }
 
-func MarshalJSONWithStatus(w http.ResponseWriter, i interface{}, status int) {
+func MarshalJSONWithStatus(w http.ResponseWriter, i any, status int) {
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(status)
 	if i == nil || (reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil()) {

--- a/pkg/http/marshal_test.go
+++ b/pkg/http/marshal_test.go
@@ -94,7 +94,7 @@ func TestConcatenateJSON(t *testing.T) {
 
 func TestMarshalJSONWithStatus(t *testing.T) {
 	type args struct {
-		i      interface{}
+		i      any
 		status int
 	}
 	type res struct {

--- a/pkg/oidc/error.go
+++ b/pkg/oidc/error.go
@@ -151,7 +151,7 @@ func (e *Error) WithParent(err error) *Error {
 	return e
 }
 
-func (e *Error) WithDescription(desc string, args ...interface{}) *Error {
+func (e *Error) WithDescription(desc string, args ...any) *Error {
 	e.Description = fmt.Sprintf(desc, args...)
 	return e
 }

--- a/pkg/oidc/keyset.go
+++ b/pkg/oidc/keyset.go
@@ -46,8 +46,8 @@ func GetKeyIDAndAlg(jws *jose.JSONWebSignature) (string, string) {
 //
 // will return false none or multiple match
 //
-//deprecated: use FindMatchingKey which will return an error (more specific) instead of just a bool
-//moved implementation already to FindMatchingKey
+// deprecated: use FindMatchingKey which will return an error (more specific) instead of just a bool
+// moved implementation already to FindMatchingKey
 func FindKey(keyID, use, expectedAlg string, keys ...jose.JSONWebKey) (jose.JSONWebKey, bool) {
 	key, err := FindMatchingKey(keyID, use, expectedAlg, keys...)
 	return key, err == nil
@@ -91,7 +91,7 @@ func FindMatchingKey(keyID, use, expectedAlg string, keys ...jose.JSONWebKey) (k
 	return key, ErrKeyNone
 }
 
-func algToKeyType(key interface{}, alg string) bool {
+func algToKeyType(key any, alg string) bool {
 	switch alg[0] {
 	case 'R', 'P':
 		_, ok := key.(*rsa.PublicKey)

--- a/pkg/oidc/regression_test.go
+++ b/pkg/oidc/regression_test.go
@@ -17,7 +17,7 @@ const dataDir = "regression_data"
 
 // jsonFilename builds a filename for the regression testdata.
 // dataDir/<type_name>.json
-func jsonFilename(obj interface{}) string {
+func jsonFilename(obj any) string {
 	name := fmt.Sprintf("%T.json", obj)
 	return path.Join(
 		dataDir,
@@ -25,13 +25,13 @@ func jsonFilename(obj interface{}) string {
 	)
 }
 
-func encodeJSON(t *testing.T, w io.Writer, obj interface{}) {
+func encodeJSON(t *testing.T, w io.Writer, obj any) {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "\t")
 	require.NoError(t, enc.Encode(obj))
 }
 
-var regressionData = []interface{}{
+var regressionData = []any{
 	accessTokenData,
 	idTokenData,
 	introspectionResponseData,

--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -222,7 +222,7 @@ type JWTProfileAssertionClaims struct {
 	Expiration   Time     `json:"exp"`
 	IssuedAt     Time     `json:"iat"`
 
-	Claims map[string]interface{} `json:"-"`
+	Claims map[string]any `json:"-"`
 }
 
 type jpaAlias JWTProfileAssertionClaims
@@ -262,7 +262,7 @@ func JWTProfileDelegatedSubject(sub string) func(*JWTProfileAssertionClaims) {
 	}
 }
 
-func JWTProfileCustomClaim(key string, value interface{}) func(*JWTProfileAssertionClaims) {
+func JWTProfileCustomClaim(key string, value any) func(*JWTProfileAssertionClaims) {
 	return func(j *JWTProfileAssertionClaims) {
 		j.Claims[key] = value
 	}
@@ -292,7 +292,7 @@ func NewJWTProfileAssertion(userID, keyID string, audience []string, key []byte,
 		IssuedAt:     FromTime(time.Now().UTC()),
 		Expiration:   FromTime(time.Now().Add(1 * time.Hour).UTC()),
 		Audience:     audience,
-		Claims:       make(map[string]interface{}),
+		Claims:       make(map[string]any),
 	}
 
 	for _, opt := range opts {

--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -130,7 +130,7 @@ type JWTTokenRequest struct {
 	IssuedAt  Time                `json:"iat"`
 	ExpiresAt Time                `json:"exp"`
 
-	private map[string]interface{}
+	private map[string]any
 }
 
 func (j *JWTTokenRequest) MarshalJSON() ([]byte, error) {
@@ -171,7 +171,7 @@ func (j *JWTTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (j *JWTTokenRequest) GetCustomClaim(key string) interface{} {
+func (j *JWTTokenRequest) GetCustomClaim(key string) any {
 	return j.private[key]
 }
 

--- a/pkg/oidc/token_test.go
+++ b/pkg/oidc/token_test.go
@@ -29,7 +29,7 @@ var (
 	accessTokenData = &AccessTokenClaims{
 		TokenClaims: tokenClaimsData,
 		Scopes:      []string{"email", "phone"},
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -43,7 +43,7 @@ var (
 		UserInfoEmail:   userInfoData.UserInfoEmail,
 		UserInfoPhone:   userInfoData.UserInfoPhone,
 		Address:         userInfoData.Address,
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -64,7 +64,7 @@ var (
 		UserInfoEmail:   userInfoData.UserInfoEmail,
 		UserInfoPhone:   userInfoData.UserInfoPhone,
 		Address:         userInfoData.Address,
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -102,7 +102,7 @@ var (
 			PostalCode:    "666-666",
 			Country:       "Moon",
 		},
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -114,7 +114,7 @@ var (
 		Audience:     Audience{"foo", "bar"},
 		Expiration:   12345,
 		IssuedAt:     12000,
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -181,7 +181,7 @@ func TestIDTokenClaims_SetUserInfo(t *testing.T) {
 		UserInfoEmail:   userInfoData.UserInfoEmail,
 		UserInfoPhone:   userInfoData.UserInfoPhone,
 		Address:         userInfoData.Address,
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"foo": "bar",
 		},
 	}

--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -17,13 +17,13 @@ import (
 type Audience []string
 
 func (a *Audience) UnmarshalJSON(text []byte) error {
-	var i interface{}
+	var i any
 	err := json.Unmarshal(text, &i)
 	if err != nil {
 		return err
 	}
 	switch aud := i.(type) {
-	case []interface{}:
+	case []any:
 		*a = make([]string, len(aud))
 		for i, audience := range aud {
 			(*a)[i] = audience.(string)
@@ -177,7 +177,7 @@ func (s *SpaceDelimitedArray) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (s *SpaceDelimitedArray) Scan(src interface{}) error {
+func (s *SpaceDelimitedArray) Scan(src any) error {
 	if src == nil {
 		*s = nil
 		return nil

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -85,7 +85,7 @@ func DecryptToken(tokenString string) (string, error) {
 	return tokenString, nil // TODO: impl
 }
 
-func ParseToken(tokenString string, claims interface{}) ([]byte, error) {
+func ParseToken(tokenString string, claims any) ([]byte, error) {
 	parts := strings.Split(tokenString, ".")
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("%w: token contains an invalid number of segments", ErrParse)

--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -501,7 +501,7 @@ func BuildAuthRequestCode(authReq AuthRequest, crypto Crypto) (string, error) {
 
 // AuthResponseURL encodes the authorization response (successful and error) and sets it as query or fragment values
 // depending on the response_mode and response_type
-func AuthResponseURL(redirectURI string, responseType oidc.ResponseType, responseMode oidc.ResponseMode, response interface{}, encoder httphelper.Encoder) (string, error) {
+func AuthResponseURL(redirectURI string, responseType oidc.ResponseType, responseMode oidc.ResponseMode, response any, encoder httphelper.Encoder) (string, error) {
 	uri, err := url.Parse(redirectURI)
 	if err != nil {
 		return "", oidc.ErrServerError().WithParent(err)

--- a/pkg/op/auth_request_test.go
+++ b/pkg/op/auth_request_test.go
@@ -745,7 +745,7 @@ func TestAuthResponseURL(t *testing.T) {
 		redirectURI  string
 		responseType oidc.ResponseType
 		responseMode oidc.ResponseMode
-		response     interface{}
+		response     any
 		encoder      httphelper.Encoder
 	}
 	type res struct {
@@ -763,7 +763,7 @@ func TestAuthResponseURL(t *testing.T) {
 				"uri",
 				oidc.ResponseTypeCode,
 				"",
-				map[string]interface{}{"test": "test"},
+				map[string]any{"test": "test"},
 				&mockEncoder{
 					errors.New("error encoding"),
 				},
@@ -934,7 +934,7 @@ type mockEncoder struct {
 	err error
 }
 
-func (m *mockEncoder) Encode(src interface{}, dst map[string][]string) error {
+func (m *mockEncoder) Encode(src any, dst map[string][]string) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/pkg/op/signer.go
+++ b/pkg/op/signer.go
@@ -10,7 +10,7 @@ var ErrSignerCreationFailed = errors.New("signer creation failed")
 
 type SigningKey interface {
 	SignatureAlgorithm() jose.SignatureAlgorithm
-	Key() interface{}
+	Key() any
 	ID() string
 }
 
@@ -32,5 +32,5 @@ type Key interface {
 	ID() string
 	Algorithm() jose.SignatureAlgorithm
 	Use() string
-	Key() interface{}
+	Key() any
 }

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -100,7 +100,7 @@ type TokenExchangeStorage interface {
 
 	// GetPrivateClaimsFromTokenExchangeRequest will be called during access token creation.
 	// Claims evaluation can be based on all validated request data available, including: scopes, resource, audience, etc.
-	GetPrivateClaimsFromTokenExchangeRequest(ctx context.Context, request TokenExchangeRequest) (claims map[string]interface{}, err error)
+	GetPrivateClaimsFromTokenExchangeRequest(ctx context.Context, request TokenExchangeRequest) (claims map[string]any, err error)
 
 	// SetUserinfoFromTokenExchangeRequest will be called during id token creation.
 	// Claims evaluation can be based on all validated request data available, including: scopes, resource, audience, etc.
@@ -110,8 +110,8 @@ type TokenExchangeStorage interface {
 // TokenExchangeTokensVerifierStorage is an optional interface used in token exchange process to verify tokens
 // issued by third-party applications. If interface is not implemented - only tokens issued by op will be exchanged.
 type TokenExchangeTokensVerifierStorage interface {
-	VerifyExchangeSubjectToken(ctx context.Context, token string, tokenType oidc.TokenType) (tokenIDOrToken string, subject string, tokenClaims map[string]interface{}, err error)
-	VerifyExchangeActorToken(ctx context.Context, token string, tokenType oidc.TokenType) (tokenIDOrToken string, actor string, tokenClaims map[string]interface{}, err error)
+	VerifyExchangeSubjectToken(ctx context.Context, token string, tokenType oidc.TokenType) (tokenIDOrToken string, subject string, tokenClaims map[string]any, err error)
+	VerifyExchangeActorToken(ctx context.Context, token string, tokenType oidc.TokenType) (tokenIDOrToken string, actor string, tokenClaims map[string]any, err error)
 }
 
 var ErrInvalidRefreshToken = errors.New("invalid_refresh_token")
@@ -126,7 +126,7 @@ type OPStorage interface {
 	SetUserinfoFromScopes(ctx context.Context, userinfo *oidc.UserInfo, userID, clientID string, scopes []string) error
 	SetUserinfoFromToken(ctx context.Context, userinfo *oidc.UserInfo, tokenID, subject, origin string) error
 	SetIntrospectionFromToken(ctx context.Context, userinfo *oidc.IntrospectionResponse, tokenID, subject, clientID string) error
-	GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (map[string]interface{}, error)
+	GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (map[string]any, error)
 	GetKeyByIDAndClientID(ctx context.Context, keyID, clientID string) (*jose.JSONWebKey, error)
 	ValidateJWTProfileScopes(ctx context.Context, userID string, scopes []string) ([]string, error)
 }

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -122,7 +122,7 @@ func CreateJWT(ctx context.Context, issuer string, tokenRequest TokenRequest, ex
 		restrictedScopes := client.RestrictAdditionalAccessTokenScopes()(tokenRequest.GetScopes())
 
 		var (
-			privateClaims map[string]interface{}
+			privateClaims map[string]any
 			err           error
 		)
 

--- a/pkg/op/token_exchange.go
+++ b/pkg/op/token_exchange.go
@@ -24,12 +24,12 @@ type TokenExchangeRequest interface {
 	GetExchangeSubject() string
 	GetExchangeSubjectTokenType() oidc.TokenType
 	GetExchangeSubjectTokenIDOrToken() string
-	GetExchangeSubjectTokenClaims() map[string]interface{}
+	GetExchangeSubjectTokenClaims() map[string]any
 
 	GetExchangeActor() string
 	GetExchangeActorTokenType() oidc.TokenType
 	GetExchangeActorTokenIDOrToken() string
-	GetExchangeActorTokenClaims() map[string]interface{}
+	GetExchangeActorTokenClaims() map[string]any
 
 	SetCurrentScopes(scopes []string)
 	SetRequestedTokenType(tt oidc.TokenType)
@@ -40,12 +40,12 @@ type tokenExchangeRequest struct {
 	exchangeSubjectTokenIDOrToken string
 	exchangeSubjectTokenType      oidc.TokenType
 	exchangeSubject               string
-	exchangeSubjectTokenClaims    map[string]interface{}
+	exchangeSubjectTokenClaims    map[string]any
 
 	exchangeActorTokenIDOrToken string
 	exchangeActorTokenType      oidc.TokenType
 	exchangeActor               string
-	exchangeActorTokenClaims    map[string]interface{}
+	exchangeActorTokenClaims    map[string]any
 
 	resource           []string
 	audience           oidc.Audience
@@ -96,7 +96,7 @@ func (r *tokenExchangeRequest) GetExchangeSubjectTokenIDOrToken() string {
 	return r.exchangeSubjectTokenIDOrToken
 }
 
-func (r *tokenExchangeRequest) GetExchangeSubjectTokenClaims() map[string]interface{} {
+func (r *tokenExchangeRequest) GetExchangeSubjectTokenClaims() map[string]any {
 	return r.exchangeSubjectTokenClaims
 }
 
@@ -112,7 +112,7 @@ func (r *tokenExchangeRequest) GetExchangeActorTokenIDOrToken() string {
 	return r.exchangeActorTokenIDOrToken
 }
 
-func (r *tokenExchangeRequest) GetExchangeActorTokenClaims() map[string]interface{} {
+func (r *tokenExchangeRequest) GetExchangeActorTokenClaims() map[string]any {
 	return r.exchangeActorTokenClaims
 }
 
@@ -232,7 +232,7 @@ func ValidateTokenExchangeRequest(
 
 	var (
 		exchangeActorTokenIDOrToken, exchangeActor string
-		exchangeActorTokenClaims                   map[string]interface{}
+		exchangeActorTokenClaims                   map[string]any
 	)
 	if oidcTokenExchangeRequest.ActorToken != "" {
 		exchangeActorTokenIDOrToken, exchangeActor, exchangeActorTokenClaims, ok = GetTokenIDAndSubjectFromToken(ctx, exchanger,
@@ -281,7 +281,7 @@ func GetTokenIDAndSubjectFromToken(
 	token string,
 	tokenType oidc.TokenType,
 	isActor bool,
-) (tokenIDOrToken, subject string, claims map[string]interface{}, ok bool) {
+) (tokenIDOrToken, subject string, claims map[string]any, ok bool) {
 	switch tokenType {
 	case oidc.AccessTokenType:
 		var accessTokenClaims *oidc.AccessTokenClaims


### PR DESCRIPTION
I noticed a mixed use of `interface{}` and `any`. This PR replaces all occurances of `interface{}` with `any` to be consistent and improve readability.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

