### PR TITLE
chore: v2 maintenance releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 on:
   push:
     branches:
+      - "2.11.x"
       - main
       - next
     tags-ignore:

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,5 +1,6 @@
 module.exports = {
     branches: [
+        {name: "2.11.x"},
         {name: "main"},
         {name: "next", prerelease: true},
     ],

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,16 +9,15 @@ We currently support the following version of the OIDC framework:
 | Version  | Supported          | Branch      | Details                              |
 | -------- | ------------------ | ----------- | ------------------------------------ |
 | 0.x.x    | :x:                |             | not maintained                       |
-| <1.13    | :x:                |             | not maintained                       |
-| 1.13.x   | :lock: :warning:   | [1.13.x][1] | security only, [community effort][2] |
-| 2.x.x    | :heavy_check_mark: | [main][3]   | supported                            |
-| 3.0.0-xx | :white_check_mark: | [next][4]   | [developement branch][5]             |
+| <2.11    | :x:                |             | not maintained                       |
+| 2.11.x   | :lock: :warning:   | [2.11.x][1] | security only, [community effort][2] |
+| 3.x.x    | :heavy_check_mark: | [main][3]   | supported                            |
+| 4.0.0-xx | :white_check_mark: | [next][4]   | [development branch]                |
 
-[1]: https://github.com/zitadel/oidc/tree/1.13.x
-[2]: https://github.com/zitadel/oidc/discussions/378
+[1]: https://github.com/zitadel/oidc/tree/2.11.x
+[2]: https://github.com/zitadel/oidc/discussions/458
 [3]: https://github.com/zitadel/oidc/tree/main
 [4]: https://github.com/zitadel/oidc/tree/next
-[5]: https://github.com/zitadel/oidc/milestone/2
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Update the releaser and SECURITY.md to match the info from the the 2.11.x branch.