### PR TITLE
fix(op): return state in token response only for implicit flow

### DIFF
--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -52,7 +52,7 @@ func CreateTokenResponse(ctx context.Context, request IDTokenRequest, client Cli
 			return nil, err
 		}
 		// only implicit flow requires state to be returned.
-		if code != "" {
+		if code == "" {
 			state = authRequest.GetState()
 		}
 	}

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -51,7 +51,10 @@ func CreateTokenResponse(ctx context.Context, request IDTokenRequest, client Cli
 		if err != nil {
 			return nil, err
 		}
-		state = authRequest.GetState()
+		// only implicit flow requires state to be returned.
+		if code != "" {
+			state = authRequest.GetState()
+		}
 	}
 
 	exp := uint64(validity.Seconds())


### PR DESCRIPTION
Return state as part of the token response only for implicit flow. For code flow the state should not be returned as part of the token response.

Closes #446

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

