### PR TITLE
docs: update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-At ZITADEL we are extremely grateful for security aware people that disclose vulnerabilities to us and the open source community. All reports will be investigated by our team.
+Please refer to the security policy [on zitadel/zitadel](https://github.com/zitadel/zitadel/blob/main/SECURITY.md) which is applicable for all open source repositories of our organization.
 
 ## Supported Versions
 
@@ -19,33 +19,3 @@ We currently support the following version of the OIDC framework:
 [3]: https://github.com/zitadel/oidc/tree/main
 [4]: https://github.com/zitadel/oidc/tree/next
 [5]: https://github.com/zitadel/oidc/milestone/2
-
-## Reporting a vulnerability
-
-To file a incident, please disclose by email to security@zitadel.com with the security details.
-
-At the moment GPG encryption is no yet supported, however you may sign your message at will.
-
-### When should I report a vulnerability
-
-* You think you discovered a ...
-  * ... potential security vulnerability in the SDK
-  * ... vulnerability in another project that this SDK bases on
-* For projects with their own vulnerability reporting and disclosure process, please report it directly there
-
-### When should I NOT report a vulnerability
-
-* You need help applying security related updates
-* Your issue is not security related
-
-## Security Vulnerability Response
-
-TBD
-
-## Public Disclosure
-
-All accepted and mitigated vulnerabilities will be published on the [Github Security Page](https://github.com/zitadel/oidc/security/advisories)
-
-### Timing
-
-We think it is crucial to publish advisories `ASAP` as mitigations are ready. But due to the unknown nature of the disclosures the time frame can range from 7 to 90 days.


### PR DESCRIPTION
The security policy on zitadel/zitadel is applicable for all open source repositories. 

It is easier to manage one security policy outlining the process and details. The exisitng security policies also outlines the missing TBD. sections of the existing policy.

The scope of supported versions can remain in this repository, as it further specifies the policie's scope.