### PR TITLE
fix(op): terminate session from request in legacy server

### DIFF
--- a/pkg/op/server_legacy.go
+++ b/pkg/op/server_legacy.go
@@ -336,9 +336,14 @@ func (s *LegacyServer) EndSession(ctx context.Context, r *Request[oidc.EndSessio
 	if err != nil {
 		return nil, err
 	}
-	err = s.provider.Storage().TerminateSession(ctx, session.UserID, session.ClientID)
+	redirect := session.RedirectURI
+	if fromRequest, ok := s.provider.Storage().(CanTerminateSessionFromRequest); ok {
+		redirect, err = fromRequest.TerminateSessionFromRequest(ctx, session)
+	} else {
+		err = s.provider.Storage().TerminateSession(ctx, session.UserID, session.ClientID)
+	}
 	if err != nil {
 		return nil, err
 	}
-	return NewRedirect(session.RedirectURI), nil
+	return NewRedirect(redirect), nil
 }


### PR DESCRIPTION
This change adds the `CanTerminateSessionFromRequest` interface to the `LegecyServer` `TerminateSession` method. The optional interface was added to the `v2` OP while `v3` was still in the making. Therefore it was missed .

Related https://github.com/zitadel/zitadel/issues/6619

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

