### PR TITLE
fix(server): do not get client by id for introspection

### DIFF
--- a/pkg/op/server.go
+++ b/pkg/op/server.go
@@ -127,7 +127,7 @@ type Server interface {
 	// Introspect handles the OAuth 2.0 Token Introspection endpoint.
 	// https://datatracker.ietf.org/doc/html/rfc7662
 	// The recommended Response Data type is [oidc.IntrospectionResponse].
-	Introspect(context.Context, *ClientRequest[oidc.IntrospectionRequest]) (*Response, error)
+	Introspect(context.Context, *Request[IntrospectionRequest]) (*Response, error)
 
 	// UserInfo handles the UserInfo endpoint and returns Claims about the authenticated End-User.
 	// https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
@@ -329,7 +329,7 @@ func (UnimplementedServer) DeviceToken(ctx context.Context, r *ClientRequest[oid
 	return nil, unimplementedGrantError(oidc.GrantTypeDeviceCode)
 }
 
-func (UnimplementedServer) Introspect(ctx context.Context, r *ClientRequest[oidc.IntrospectionRequest]) (*Response, error) {
+func (UnimplementedServer) Introspect(ctx context.Context, r *Request[IntrospectionRequest]) (*Response, error) {
 	return nil, unimplementedError(r)
 }
 

--- a/pkg/op/server_http_test.go
+++ b/pkg/op/server_http_test.go
@@ -1001,14 +1001,12 @@ func Test_webServer_introspectionHandler(t *testing.T) {
 	tests := []struct {
 		name    string
 		decoder httphelper.Decoder
-		client  Client
 		r       *http.Request
 		want    webServerResult
 	}{
 		{
 			name:    "decoder error",
 			decoder: schema.NewDecoder(),
-			client:  newClient(clientTypeUserAgent),
 			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("foo=bar")),
 			want: webServerResult{
 				wantStatus: http.StatusBadRequest,
@@ -1018,8 +1016,7 @@ func Test_webServer_introspectionHandler(t *testing.T) {
 		{
 			name:    "public client",
 			decoder: testDecoder,
-			client:  newClient(clientTypeNative),
-			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("foo=bar")),
+			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("client_id=123")),
 			want: webServerResult{
 				wantStatus: http.StatusBadRequest,
 				wantBody:   `{"error":"invalid_client", "error_description":"client must be authenticated"}`,
@@ -1028,8 +1025,7 @@ func Test_webServer_introspectionHandler(t *testing.T) {
 		{
 			name:    "token missing",
 			decoder: testDecoder,
-			client:  newClient(clientTypeWeb),
-			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("foo=bar")),
+			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("client_id=123&client_secret=SECRET")),
 			want: webServerResult{
 				wantStatus: http.StatusBadRequest,
 				wantBody:   `{"error":"invalid_request", "error_description":"token missing"}`,
@@ -1038,8 +1034,7 @@ func Test_webServer_introspectionHandler(t *testing.T) {
 		{
 			name:    "unimplemented Introspect called",
 			decoder: testDecoder,
-			client:  newClient(clientTypeWeb),
-			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("token=xxx")),
+			r:       httptest.NewRequest(http.MethodPost, "/", strings.NewReader("client_id=123&client_secret=SECRET&token=xxx")),
 			want: webServerResult{
 				wantStatus: UnimplementedStatusCode,
 				wantBody:   `{"error":"server_error", "error_description":"/ not implemented on this server"}`,
@@ -1053,7 +1048,7 @@ func Test_webServer_introspectionHandler(t *testing.T) {
 				decoder: tt.decoder,
 				logger:  slog.Default(),
 			}
-			runWebServerClientTest(t, s.introspectionHandler, tt.r, tt.client, tt.want)
+			runWebServerTest(t, s.introspectionHandler, tt.r, tt.want)
 		})
 	}
 }

--- a/pkg/op/server_legacy.go
+++ b/pkg/op/server_legacy.go
@@ -307,13 +307,30 @@ func (s *LegacyServer) DeviceToken(ctx context.Context, r *ClientRequest[oidc.De
 	return NewResponse(resp), nil
 }
 
-func (s *LegacyServer) Introspect(ctx context.Context, r *ClientRequest[oidc.IntrospectionRequest]) (*Response, error) {
+func (s *LegacyServer) authenticateResourceClient(ctx context.Context, cc *ClientCredentials) (string, error) {
+	if cc.ClientAssertion != "" {
+		if jp, ok := s.provider.(ClientJWTProfile); ok {
+			return ClientJWTAuth(ctx, oidc.ClientAssertionParams{ClientAssertion: cc.ClientAssertion}, jp)
+		}
+		return "", oidc.ErrInvalidClient().WithDescription("client_assertion not supported")
+	}
+	if err := s.provider.Storage().AuthorizeClientIDSecret(ctx, cc.ClientID, cc.ClientSecret); err != nil {
+		return "", oidc.ErrUnauthorizedClient().WithParent(err)
+	}
+	return cc.ClientID, nil
+}
+
+func (s *LegacyServer) Introspect(ctx context.Context, r *Request[IntrospectionRequest]) (*Response, error) {
+	clientID, err := s.authenticateResourceClient(ctx, r.Data.ClientCredentials)
+	if err != nil {
+		return nil, err
+	}
 	response := new(oidc.IntrospectionResponse)
 	tokenID, subject, ok := getTokenIDAndSubject(ctx, s.provider, r.Data.Token)
 	if !ok {
 		return NewResponse(response), nil
 	}
-	err := s.provider.Storage().SetIntrospectionFromToken(ctx, response, tokenID, subject, r.Client.GetID())
+	err = s.provider.Storage().SetIntrospectionFromToken(ctx, response, tokenID, subject, clientID)
 	if err != nil {
 		return NewResponse(response), nil
 	}

--- a/pkg/op/token_intospection.go
+++ b/pkg/op/token_intospection.go
@@ -65,3 +65,8 @@ func ParseTokenIntrospectionRequest(r *http.Request, introspector Introspector) 
 
 	return req.Token, clientID, nil
 }
+
+type IntrospectionRequest struct {
+	*ClientCredentials
+	*oidc.IntrospectionRequest
+}


### PR DESCRIPTION
As introspection is a Oauth mechanism for resource servers only, it does not make sense to get an oidc client by ID. The original OP did not do this and now we make the server behavior similar.

Tested in zitadel commit https://github.com/zitadel/zitadel/commit/ac5122d2acc3da79b2bb92e5cd5c5aeeabb22872

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

