### PR TITLE
feat: Allow CORS policy to be configured

### DIFF
--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -624,6 +624,6 @@ func intercept(i IssuerFromRequest, interceptors ...HttpInterceptor) func(handle
 		for i := len(interceptors) - 1; i >= 0; i-- {
 			handler = interceptors[i](handler)
 		}
-		return cors.New(defaultCORSOptions).Handler(issuerInterceptor.Handler(handler))
+		return issuerInterceptor.Handler(handler)
 	}
 }

--- a/pkg/op/server_http.go
+++ b/pkg/op/server_http.go
@@ -38,8 +38,9 @@ func RegisterServer(server Server, endpoints Endpoints, options ...ServerOption)
 	}
 
 	ws.createRouter()
+	ws.handler = ws.router
 	if ws.corsOpts != nil {
-		return cors.New(*ws.corsOpts).Handler(ws)
+		ws.handler = cors.New(*ws.corsOpts).Handler(ws.router)
 	}
 	return ws
 }
@@ -88,6 +89,7 @@ func WithFallbackLogger(logger *slog.Logger) ServerOption {
 type webServer struct {
 	server    Server
 	router    *chi.Mux
+	handler   http.Handler
 	endpoints Endpoints
 	decoder   httphelper.Decoder
 	corsOpts  *cors.Options
@@ -95,7 +97,7 @@ type webServer struct {
 }
 
 func (s *webServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.router.ServeHTTP(w, r)
+	s.handler.ServeHTTP(w, r)
 }
 
 func (s *webServer) getLogger(ctx context.Context) *slog.Logger {

--- a/pkg/op/server_http.go
+++ b/pkg/op/server_http.go
@@ -29,7 +29,7 @@ func RegisterServer(server Server, endpoints Endpoints, options ...ServerOption)
 		server:    server,
 		endpoints: endpoints,
 		decoder:   decoder,
-		corsOpts:  defaultCORSOptions,
+		corsOpts:  &defaultCORSOptions,
 		logger:    slog.Default(),
 	}
 
@@ -38,7 +38,10 @@ func RegisterServer(server Server, endpoints Endpoints, options ...ServerOption)
 	}
 
 	ws.createRouter()
-	return cors.New(ws.corsOpts).Handler(ws)
+	if ws.corsOpts != nil {
+		return cors.New(*ws.corsOpts).Handler(ws)
+	}
+	return ws
 }
 
 type ServerOption func(s *webServer)
@@ -67,7 +70,7 @@ func WithDecoder(decoder httphelper.Decoder) ServerOption {
 }
 
 // WithServerCORSOptions sets the CORS policy for the Server's router.
-func WithServerCORSOptions(opts cors.Options) ServerOption {
+func WithServerCORSOptions(opts *cors.Options) ServerOption {
 	return func(s *webServer) {
 		s.corsOpts = opts
 	}
@@ -87,7 +90,7 @@ type webServer struct {
 	router    *chi.Mux
 	endpoints Endpoints
 	decoder   httphelper.Decoder
-	corsOpts  cors.Options
+	corsOpts  *cors.Options
 	logger    *slog.Logger
 }
 


### PR DESCRIPTION
This allows the CORS policy to be configured or disabled on an `op.Provider` via `WithCORSOptions` or on `on.RegisterServer` via `WithServerCORSOptions`. The reason for this feature is library users may want a stricter CORS policy than the default policy currently forced by the library.

This takes care not to break backwards compatibility with any interfaces, functions, or default usage (e.g. the default policy is still applied by default).

Also, this removes the CORS middleware from the `intercept` function as every upstream use of it already had the CORS middleware applied.
