### PR TITLE
fix(examples): Offer Storage with non-global client

### DIFF
--- a/example/server/storage/storage.go
+++ b/example/server/storage/storage.go
@@ -90,6 +90,10 @@ func (s *publicKey) Key() any {
 }
 
 func NewStorage(userStore UserStore) *Storage {
+	return NewStorageWithClients(userStore, clients)
+}
+
+func NewStorageWithClients(userStore UserStore, clients map[string]*Client) *Storage {
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	return &Storage{
 		authRequests:  make(map[string]*AuthRequest),


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

---

I'm using the example code in my tests to setup a thin OIDC server. It works fine until I enable parallel tests, because go raises race warnings.