### PR TITLE
PKCE Verification in Legacy Server when AuthMethod is not NONE and CodeVerifier is not Empty

### DIFF
--- a/pkg/op/server_legacy.go
+++ b/pkg/op/server_legacy.go
@@ -205,7 +205,12 @@ func (s *LegacyServer) CodeExchange(ctx context.Context, r *ClientRequest[oidc.A
 	if err != nil {
 		return nil, err
 	}
+
 	if r.Client.AuthMethod() == oidc.AuthMethodNone {
+		if err = AuthorizeCodeChallenge(r.Data.CodeVerifier, authReq.GetCodeChallenge()); err != nil {
+			return nil, err
+		}
+	} else if r.Data.CodeVerifier != "" {
 		if err = AuthorizeCodeChallenge(r.Data.CodeVerifier, authReq.GetCodeChallenge()); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION

Related to [Issue 254](https://github.com/zitadel/oidc/issues/254) and [Issue 6886](https://github.com/zitadel/zitadel/issues/6886)

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

