### PR TITLE
fix(oidc): ignore unknown language tag in userinfo unmarshal

### DIFF
--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -77,7 +78,17 @@ func (l *Locale) MarshalJSON() ([]byte, error) {
 }
 
 func (l *Locale) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &l.tag)
+	err := json.Unmarshal(data, &l.tag)
+	if err == nil {
+		return nil
+	}
+
+	// catch "well-formed but unknown" errors
+	var target language.ValueError
+	if errors.As(err, &target) {
+		return nil
+	}
+	return err
 }
 
 type Locales []language.Tag

--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -77,6 +77,10 @@ func (l *Locale) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tag)
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+// When [language.ValueError] is encountered, the containing tag will be set
+// to an empty value (language "und") and no error will be returned.
+// This state can be checked with the `l.Tag().IsRoot()` method.
 func (l *Locale) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &l.tag)
 	if err == nil {
@@ -86,6 +90,7 @@ func (l *Locale) UnmarshalJSON(data []byte) error {
 	// catch "well-formed but unknown" errors
 	var target language.ValueError
 	if errors.As(err, &target) {
+		l.tag = language.Tag{}
 		return nil
 	}
 	return err

--- a/pkg/oidc/types_test.go
+++ b/pkg/oidc/types_test.go
@@ -208,20 +208,46 @@ func TestLocale_MarshalJSON(t *testing.T) {
 }
 
 func TestLocale_UnmarshalJSON(t *testing.T) {
-	type a struct {
+	type dst struct {
 		Locale *Locale `json:"locale,omitempty"`
 	}
-	want := a{
-		Locale: NewLocale(language.Afrikaans),
+	tests := []struct {
+		name    string
+		input   string
+		want    dst
+		wantErr bool
+	}{
+		{
+			name:  "afrikaans, ok",
+			input: `{"locale": "af"}`,
+			want: dst{
+				Locale: NewLocale(language.Afrikaans),
+			},
+		},
+		{
+			name:  "gb, ignored",
+			input: `{"locale": "gb"}`,
+			want: dst{
+				Locale: &Locale{},
+			},
+		},
+		{
+			name:    "bad form, error",
+			input:   `{"locale": "g!!!!!"}`,
+			wantErr: true,
+		},
 	}
 
-	const input = `{"locale": "af"}`
-	var got a
-
-	require.NoError(t,
-		json.Unmarshal([]byte(input), &got),
-	)
-	assert.Equal(t, want, got)
+	for _, tt := range tests {
+		var got dst
+		err := json.Unmarshal([]byte(tt.input), &got)
+		if tt.wantErr {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got)
+	}
 }
 
 func TestParseLocales(t *testing.T) {

--- a/pkg/oidc/userinfo.go
+++ b/pkg/oidc/userinfo.go
@@ -41,13 +41,7 @@ func (u *UserInfo) MarshalJSON() ([]byte, error) {
 }
 
 func (u *UserInfo) UnmarshalJSON(data []byte) error {
-	if err := unmarshalJSONMulti(data, (*uiAlias)(u), &u.Claims); err != nil {
-		return err
-	}
-	if u.Locale != nil && u.Locale.tag.IsRoot() {
-		u.Locale = nil
-	}
-	return nil
+	return unmarshalJSONMulti(data, (*uiAlias)(u), &u.Claims)
 }
 
 type UserInfoProfile struct {

--- a/pkg/oidc/userinfo.go
+++ b/pkg/oidc/userinfo.go
@@ -41,7 +41,13 @@ func (u *UserInfo) MarshalJSON() ([]byte, error) {
 }
 
 func (u *UserInfo) UnmarshalJSON(data []byte) error {
-	return unmarshalJSONMulti(data, (*uiAlias)(u), &u.Claims)
+	if err := unmarshalJSONMulti(data, (*uiAlias)(u), &u.Claims); err != nil {
+		return err
+	}
+	if u.Locale != nil && u.Locale.tag.IsRoot() {
+		u.Locale = nil
+	}
+	return nil
 }
 
 type UserInfoProfile struct {


### PR DESCRIPTION
Open system reported an issue where a generic OpenID provider might return language tags like "gb".
These tags are well-formed but unknown and Go returns an error for it.
We already ignored unknown tags is ui_locale arrays lik in AuthRequest.

This change ignores singular unknown tags, like used in the userinfo `locale` claim.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

