### PR TITLE
fix: Implement package-level error for RevokeToken

### DIFF
--- a/pkg/client/rp/errors.go
+++ b/pkg/client/rp/errors.go
@@ -1,0 +1,5 @@
+package rp
+
+import "errors"
+
+var ErrRelyingPartyNotSupportRevokeCaller = errors.New("RelyingParty does not support RevokeCaller")

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
-	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 	"github.com/google/uuid"
 	"github.com/zitadel/logging"
 	"golang.org/x/exp/slog"
@@ -726,5 +725,5 @@ func RevokeToken(ctx context.Context, rp RelyingParty, token string, tokenTypeHi
 	if rc, ok := rp.(client.RevokeCaller); ok && rc.GetRevokeEndpoint() != "" {
 		return client.CallRevokeEndpoint(ctx, request, nil, rc)
 	}
-	return fmt.Errorf("RelyingParty does not support RevokeCaller")
+	return ErrRelyingPartyNotSupportRevokeCaller
 }


### PR DESCRIPTION
By using package-level errors, as library consumer I'm able to catch specific error without do a string compare of the error messages.

After the PR, I can use `errors.Is(err, rp.ErrRelyingPartyNotSupportRevokeCaller)` to catch the specific error.

See: https://go.dev/blog/go1.13-errors

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

