### PR TITLE
fix: don't force server errors in legacy server

### DIFF
--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -138,20 +138,20 @@ func ParseRequestObject(ctx context.Context, authReq *oidc.AuthRequest, storage 
 	}
 
 	if requestObject.ClientID != "" && requestObject.ClientID != authReq.ClientID {
-		return oidc.ErrInvalidRequest()
+		return oidc.ErrInvalidRequest().WithDescription("missing or wrong client id in request")
 	}
 	if requestObject.ResponseType != "" && requestObject.ResponseType != authReq.ResponseType {
-		return oidc.ErrInvalidRequest()
+		return oidc.ErrInvalidRequest().WithDescription("missing or wrong response type in request")
 	}
 	if requestObject.Issuer != requestObject.ClientID {
-		return oidc.ErrInvalidRequest()
+		return oidc.ErrInvalidRequest().WithDescription("missing or wrong issuer in request")
 	}
 	if !str.Contains(requestObject.Audience, issuer) {
-		return oidc.ErrInvalidRequest()
+		return oidc.ErrInvalidRequest().WithDescription("issuer missing in audience")
 	}
 	keySet := &jwtProfileKeySet{storage: storage, clientID: requestObject.Issuer}
 	if err = oidc.CheckSignature(ctx, authReq.RequestParam, payload, requestObject, nil, keySet); err != nil {
-		return err
+		return oidc.ErrInvalidRequest().WithParent(err).WithDescription(err.Error())
 	}
 	CopyRequestObjectToAuthRequest(authReq, requestObject)
 	return nil

--- a/pkg/op/error_test.go
+++ b/pkg/op/error_test.go
@@ -579,7 +579,7 @@ func TestWriteError(t *testing.T) {
 		{
 			name:       "not a status or oidc error",
 			err:        io.ErrClosedPipe,
-			wantStatus: http.StatusBadRequest,
+			wantStatus: http.StatusInternalServerError,
 			wantBody: `{
 				"error":"server_error",
 				"error_description":"io: read/write on closed pipe"
@@ -592,6 +592,7 @@ func TestWriteError(t *testing.T) {
 					"parent":"io: read/write on closed pipe",
 					"type":"server_error"
 				},
+				"status_code":500,
 				"time":"not"
 			}`,
 		},
@@ -611,6 +612,7 @@ func TestWriteError(t *testing.T) {
 					"parent":"io: read/write on closed pipe",
 					"type":"server_error"
 				},
+				"status_code":500,
 				"time":"not"
 			}`,
 		},
@@ -629,6 +631,7 @@ func TestWriteError(t *testing.T) {
 					"description":"oops",
 					"type":"invalid_request"
 				},
+				"status_code":400,
 				"time":"not"
 			}`,
 		},
@@ -650,6 +653,7 @@ func TestWriteError(t *testing.T) {
 					"description":"oops",
 					"type":"unauthorized_client"
 				},
+				"status_code":401,
 				"time":"not"
 			}`,
 		},

--- a/pkg/op/server_http_test.go
+++ b/pkg/op/server_http_test.go
@@ -365,14 +365,14 @@ func Test_webServer_authorizeHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "authorize error",
+			name: "server error",
 			fields: fields{
 				server:  &requestVerifier{},
 				decoder: testDecoder,
 			},
 			r: httptest.NewRequest(http.MethodPost, "/authorize", strings.NewReader("foo=bar")),
 			want: webServerResult{
-				wantStatus: http.StatusBadRequest,
+				wantStatus: http.StatusInternalServerError,
 				wantBody:   `{"error":"server_error"}`,
 			},
 		},
@@ -1237,7 +1237,7 @@ func Test_webServer_simpleHandler(t *testing.T) {
 			},
 			r: httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(make([]byte, 11<<20))),
 			want: webServerResult{
-				wantStatus: http.StatusBadRequest,
+				wantStatus: http.StatusInternalServerError,
 				wantBody:   `{"error":"server_error", "error_description":"io: read/write on closed pipe"}`,
 			},
 		},


### PR DESCRIPTION
This PR changes the way we re-throw errors. In the old solution, the Legacy Server used `NewStatusError` which forces a particular HTTP status code, even if one was already set from downstream. Instead now we us `AsStatusError`. This only sets a status code if one wasn't set already.

The `WriteError` function is also rewritten to make better distinction between error types and status codes.

Related: #291

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

