### PR TITLE
fix: allow expired ID token hint to end sessions

### DIFF
--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -57,7 +57,7 @@ var (
 	ErrNonceInvalid            = errors.New("nonce does not match")
 	ErrAcrInvalid              = errors.New("acr is invalid")
 	ErrAuthTimeNotPresent      = errors.New("claim `auth_time` of token is missing")
-	ErrAuthTimeToOld           = errors.New("auth time of token is to old")
+	ErrAuthTimeToOld           = errors.New("auth time of token is too old")
 	ErrAtHash                  = errors.New("at_hash does not correspond to access token")
 )
 

--- a/pkg/op/session.go
+++ b/pkg/op/session.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"path"
@@ -68,7 +69,7 @@ func ValidateEndSessionRequest(ctx context.Context, req *oidc.EndSessionRequest,
 	}
 	if req.IdTokenHint != "" {
 		claims, err := VerifyIDTokenHint[*oidc.IDTokenClaims](ctx, req.IdTokenHint, ender.IDTokenHintVerifier(ctx))
-		if err != nil {
+		if err != nil && !errors.As(err, &IDTokenHintExpiredError{}) {
 			return nil, oidc.ErrInvalidRequest().WithDescription("id_token_hint invalid").WithParent(err)
 		}
 		session.UserID = claims.GetSubject()


### PR DESCRIPTION
This change adds a specific error for expired ID Token hints, including too old "issued at" and "max auth age".
The error is returned VerifyIDTokenHint so that the end session handler can choose to ignore this error.

This fixes the behavior to be in line with [OpenID Connect RP-Initiated Logout 1.0, section 4](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#ValidationAndErrorHandling).

Related to https://github.com/zitadel/zitadel/issues/5232

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

