### PR TITLE
fix(op): allow expired id token hints in authorize

### DIFF
--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -391,9 +391,9 @@ func ValidateAuthReqIDTokenHint(ctx context.Context, idTokenHint string, verifie
 		return "", nil
 	}
 	claims, err := VerifyIDTokenHint[*oidc.TokenClaims](ctx, idTokenHint, verifier)
-	if err != nil {
+	if err != nil && !errors.As(err, &IDTokenHintExpiredError{}) {
 		return "", oidc.ErrLoginRequired().WithDescription("The id_token_hint is invalid. " +
-			"If you have any questions, you may contact the administrator of the application.")
+			"If you have any questions, you may contact the administrator of the application.").WithParent(err)
 	}
 	return claims.GetSubject(), nil
 }


### PR DESCRIPTION
Like https://github.com/zitadel/oidc/pull/522 for end session,
this change allows passing an expired ID token hint to the authorize endpoint.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

