### PR TITLE
chore: ignore dependabot for board PRs

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -23,20 +23,20 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - uses: tspascoal/get-user-teams-membership@v3
         id: checkUserMember
-        if: github.actor == 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]'
         with:
          username: ${{ github.actor }}
          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - name: add pr
         uses: actions/add-to-project@v0.5.0
-        if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'engineers')}}
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'engineers')}}
         with:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/orgs/zitadel/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - uses: actions-ecosystem/action-add-labels@v1.1.3
-        if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
         with:
           github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labels: |


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

