### PR TITLE
feat: extend token exchange response

### DIFF
--- a/pkg/client/tokenexchange/tokenexchange.go
+++ b/pkg/client/tokenexchange/tokenexchange.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/zitadel/oidc/v3/pkg/client"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -29,6 +31,17 @@ func NewTokenExchanger(ctx context.Context, issuer string, options ...func(sourc
 func NewTokenExchangerClientCredentials(ctx context.Context, issuer, clientID, clientSecret string, options ...func(source *OAuthTokenExchange)) (TokenExchanger, error) {
 	authorizer := func() (any, error) {
 		return httphelper.AuthorizeBasic(clientID, clientSecret), nil
+	}
+	return newOAuthTokenExchange(ctx, issuer, authorizer, options...)
+}
+
+func NewTokenExchangerJWTProfile(ctx context.Context, issuer, clientID string, signer jose.Signer, options ...func(source *OAuthTokenExchange)) (TokenExchanger, error) {
+	authorizer := func() (any, error) {
+		assertion, err := client.SignedJWTProfileAssertion(clientID, []string{issuer}, time.Hour, signer)
+		if err != nil {
+			return nil, err
+		}
+		return client.ClientAssertionFormAuthorization(assertion), nil
 	}
 	return newOAuthTokenExchange(ctx, issuer, authorizer, options...)
 }

--- a/pkg/oidc/error.go
+++ b/pkg/oidc/error.go
@@ -27,6 +27,11 @@ const (
 	SlowDown             errorType = "slow_down"
 	AccessDenied         errorType = "access_denied"
 	ExpiredToken         errorType = "expired_token"
+
+	// InvalidTarget error is returned by Token Exchange if
+	// the requested target or audience is invalid.
+	// [RFC 8693, Section 2.2.2: Error Response](https://www.rfc-editor.org/rfc/rfc8693#section-2.2.2)
+	InvalidTarget errorType = "invalid_target"
 )
 
 var (
@@ -110,6 +115,14 @@ var (
 		return &Error{
 			ErrorType:   ExpiredToken,
 			Description: "The \"device_code\" has expired.",
+		}
+	}
+
+	// Token exchange error
+	ErrInvalidTarget = func() *Error {
+		return &Error{
+			ErrorType:   InvalidTarget,
+			Description: "The requested audience or target is invalid.",
 		}
 	}
 )

--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -34,19 +34,20 @@ type Tokens[C IDClaims] struct {
 // TokenClaims implements the Claims interface,
 // and can be used to extend larger claim types by embedding.
 type TokenClaims struct {
-	Issuer                              string   `json:"iss,omitempty"`
-	Subject                             string   `json:"sub,omitempty"`
-	Audience                            Audience `json:"aud,omitempty"`
-	Expiration                          Time     `json:"exp,omitempty"`
-	IssuedAt                            Time     `json:"iat,omitempty"`
-	AuthTime                            Time     `json:"auth_time,omitempty"`
-	NotBefore                           Time     `json:"nbf,omitempty"`
-	Nonce                               string   `json:"nonce,omitempty"`
-	AuthenticationContextClassReference string   `json:"acr,omitempty"`
-	AuthenticationMethodsReferences     []string `json:"amr,omitempty"`
-	AuthorizedParty                     string   `json:"azp,omitempty"`
-	ClientID                            string   `json:"client_id,omitempty"`
-	JWTID                               string   `json:"jti,omitempty"`
+	Issuer                              string       `json:"iss,omitempty"`
+	Subject                             string       `json:"sub,omitempty"`
+	Audience                            Audience     `json:"aud,omitempty"`
+	Expiration                          Time         `json:"exp,omitempty"`
+	IssuedAt                            Time         `json:"iat,omitempty"`
+	AuthTime                            Time         `json:"auth_time,omitempty"`
+	NotBefore                           Time         `json:"nbf,omitempty"`
+	Nonce                               string       `json:"nonce,omitempty"`
+	AuthenticationContextClassReference string       `json:"acr,omitempty"`
+	AuthenticationMethodsReferences     []string     `json:"amr,omitempty"`
+	AuthorizedParty                     string       `json:"azp,omitempty"`
+	ClientID                            string       `json:"client_id,omitempty"`
+	JWTID                               string       `json:"jti,omitempty"`
+	Actor                               *ActorClaims `json:"act,omitempty"`
 
 	// Additional information set by this framework
 	SignatureAlg jose.SignatureAlgorithm `json:"-"`
@@ -204,6 +205,28 @@ func (i *IDTokenClaims) UnmarshalJSON(data []byte) error {
 	return unmarshalJSONMulti(data, (*itcAlias)(i), &i.Claims)
 }
 
+// ActorClaims provides the `act` claims used for impersonation or delegation Token Exchange.
+//
+// An actor can be nested in case an obtained token is used as actor token to obtain impersonation or delegation.
+// This allows creating a chain of actors.
+// See [RFC 8693, section 4.1](https://www.rfc-editor.org/rfc/rfc8693#name-act-actor-claim).
+type ActorClaims struct {
+	Actor   *ActorClaims   `json:"act,omitempty"`
+	Issuer  string         `json:"iss,omitempty"`
+	Subject string         `json:"sub,omitempty"`
+	Claims  map[string]any `json:"-"`
+}
+
+type acAlias ActorClaims
+
+func (c *ActorClaims) MarshalJSON() ([]byte, error) {
+	return mergeAndMarshalClaims((*acAlias)(c), c.Claims)
+}
+
+func (c *ActorClaims) UnmarshalJSON(data []byte) error {
+	return unmarshalJSONMulti(data, (*acAlias)(c), &c.Claims)
+}
+
 type AccessTokenResponse struct {
 	AccessToken  string `json:"access_token,omitempty" schema:"access_token,omitempty"`
 	TokenType    string `json:"token_type,omitempty" schema:"token_type,omitempty"`
@@ -352,4 +375,8 @@ type TokenExchangeResponse struct {
 	ExpiresIn       uint64              `json:"expires_in,omitempty"`
 	Scopes          SpaceDelimitedArray `json:"scope,omitempty"`
 	RefreshToken    string              `json:"refresh_token,omitempty"`
+
+	// IDToken field allows returning an additional ID token
+	// if the requested_token_type was Access Token and scope contained openid.
+	IDToken string `json:"id_token,omitempty"`
 }

--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	jose "github.com/go-jose/go-jose/v3"
@@ -57,13 +58,7 @@ var AllTokenTypes = []TokenType{
 type TokenType string
 
 func (t TokenType) IsSupported() bool {
-	for _, tt := range AllTokenTypes {
-		if t == tt {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(AllTokenTypes, t)
 }
 
 type TokenRequest interface {


### PR DESCRIPTION
This change adds fields to the token exchange and token claims types.

The `act` claim has been added to describe the actor in case of impersonation or delegation. An actor can be nested in case an obtained token is used as actor token to obtain impersonation or delegation. This allows creating a chain of actors. See [RFC 8693, section 4.1](https://www.rfc-editor.org/rfc/rfc8693#name-act-actor-claim). The `invalid_target` error has been added as per RFC requirements.

The `id_token` field has been added to the Token Exchange response  so an ID Token can be returned along with an access token. This is not specified in RFC 8693, but it allows us be consistent with OpenID responses when the scope `openid` is set, while the requested token type may remain access token.

The token exchange client now also can use JWT Profile authentication, which was needed for integration tests in ZITADEL.

Related https://github.com/zitadel/zitadel/issues/7210

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

