### PR TITLE
feat(op): allow setting the actor to Token Requests

### DIFF
--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -118,6 +118,10 @@ func CreateBearerToken(tokenID, subject string, crypto Crypto) (string, error) {
 	return crypto.Encrypt(tokenID + ":" + subject)
 }
 
+type TokenActorRequest interface {
+	GetActor() *oidc.ActorClaims
+}
+
 func CreateJWT(ctx context.Context, issuer string, tokenRequest TokenRequest, exp time.Time, id string, client AccessTokenClient, storage Storage) (string, error) {
 	ctx, span := tracer.Start(ctx, "CreateJWT")
 	defer span.End()
@@ -146,6 +150,9 @@ func CreateJWT(ctx context.Context, issuer string, tokenRequest TokenRequest, ex
 			return "", err
 		}
 		claims.Claims = privateClaims
+	}
+	if actorReq, ok := tokenRequest.(TokenActorRequest); ok {
+		claims.Actor = actorReq.GetActor()
 	}
 	signingKey, err := storage.SigningKey(ctx)
 	if err != nil {
@@ -178,6 +185,10 @@ func CreateIDToken(ctx context.Context, issuer string, request IDTokenRequest, v
 		nonce = authRequest.GetNonce()
 	}
 	claims := oidc.NewIDTokenClaims(issuer, request.GetSubject(), request.GetAudience(), exp, request.GetAuthTime(), nonce, acr, request.GetAMR(), request.GetClientID(), client.ClockSkew())
+	if actorReq, ok := request.(TokenActorRequest); ok {
+		claims.Actor = actorReq.GetActor()
+	}
+
 	scopes := client.RestrictAdditionalIdTokenScopes()(request.GetScopes())
 	signingKey, err := storage.SigningKey(ctx)
 	if err != nil {


### PR DESCRIPTION
For impersonation token exchange we need to persist the actor throughout token requests, including refresh token.
This PR adds the optional TokenActorRequest interface which allows to pass such actor.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

