### PR TITLE
feat(oidc): add actor claim to introspection response

### DIFF
--- a/example/client/app/app.go
+++ b/example/client/app/app.go
@@ -99,6 +99,10 @@ func main() {
 
 	// for demonstration purposes the returned userinfo response is written as JSON object onto response
 	marshalUserinfo := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty, info *oidc.UserInfo) {
+		fmt.Println("access token", tokens.AccessToken)
+		fmt.Println("refresh token", tokens.RefreshToken)
+		fmt.Println("id token", tokens.IDToken)
+
 		data, err := json.Marshal(info)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/oidc/introspection.go
+++ b/pkg/oidc/introspection.go
@@ -16,18 +16,21 @@ type ClientAssertionParams struct {
 // https://www.rfc-editor.org/rfc/rfc7662.html#section-2.2.
 // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
 type IntrospectionResponse struct {
-	Active     bool                `json:"active"`
-	Scope      SpaceDelimitedArray `json:"scope,omitempty"`
-	ClientID   string              `json:"client_id,omitempty"`
-	TokenType  string              `json:"token_type,omitempty"`
-	Expiration Time                `json:"exp,omitempty"`
-	IssuedAt   Time                `json:"iat,omitempty"`
-	NotBefore  Time                `json:"nbf,omitempty"`
-	Subject    string              `json:"sub,omitempty"`
-	Audience   Audience            `json:"aud,omitempty"`
-	Issuer     string              `json:"iss,omitempty"`
-	JWTID      string              `json:"jti,omitempty"`
-	Username   string              `json:"username,omitempty"`
+	Active                          bool                `json:"active"`
+	Scope                           SpaceDelimitedArray `json:"scope,omitempty"`
+	ClientID                        string              `json:"client_id,omitempty"`
+	TokenType                       string              `json:"token_type,omitempty"`
+	Expiration                      Time                `json:"exp,omitempty"`
+	IssuedAt                        Time                `json:"iat,omitempty"`
+	AuthTime                        Time                `json:"auth_time,omitempty"`
+	NotBefore                       Time                `json:"nbf,omitempty"`
+	Subject                         string              `json:"sub,omitempty"`
+	Audience                        Audience            `json:"aud,omitempty"`
+	AuthenticationMethodsReferences []string            `json:"amr,omitempty"`
+	Issuer                          string              `json:"iss,omitempty"`
+	JWTID                           string              `json:"jti,omitempty"`
+	Username                        string              `json:"username,omitempty"`
+	Actor                           *ActorClaims        `json:"act,omitempty"`
 	UserInfoProfile
 	UserInfoEmail
 	UserInfoPhone


### PR DESCRIPTION
With impersonation we assign an actor claim to our JWT/ID Tokens. This change adds the actor claim to the introspection response to follow suit.

This PR also adds the `auth_time` and `amr` claims for consistency.

Related to https://github.com/zitadel/zitadel/issues/7210

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

