### PR TITLE
feat: return oidc.Error in case of call token failure

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
 var DefaultHTTPClient = &http.Client{
@@ -66,7 +68,12 @@ func HttpRequest(client *http.Client, req *http.Request, response any) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("http status not ok: %s %s", resp.Status, body)
+		var oidcErr oidc.Error
+		err = json.Unmarshal(body, &oidcErr)
+		if err != nil || oidcErr.ErrorType == "" {
+			return fmt.Errorf("http status not ok: %s %s", resp.Status, body)
+		}
+		return &oidcErr
 	}
 
 	err = json.Unmarshal(body, response)


### PR DESCRIPTION
Hello, Azure API is returning a well formatted oauth error when we try to generate a token with client credentials grant type for example. Respecting that RFC https://www.rfc-editor.org/rfc/rfc6749#section-5.2

But this library doesn't return a proper oidc.Error in that case which is too bad. So I took inspiration from the ``CallDeviceAccessTokenEndpoint`` and I propose you this PR.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

