### PR TITLE
fix: fetchRemoteKeys context to include in request

### DIFF
--- a/pkg/client/rp/jwks.go
+++ b/pkg/client/rp/jwks.go
@@ -217,7 +217,7 @@ func (r *remoteKeySet) fetchRemoteKeys(ctx context.Context) ([]jose.JSONWebKey, 
 	ctx, span := client.Tracer.Start(ctx, "fetchRemoteKeys")
 	defer span.End()
 
-	req, err := http.NewRequest("GET", r.jwksURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", r.jwksURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("oidc: can't create request: %v", err)
 	}


### PR DESCRIPTION
Fixed to include the context in which the span was created in the request.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

