### PR TITLE
fix: Handle case where verifier Nonce func is nil 

### DIFF
--- a/pkg/client/rp/verifier.go
+++ b/pkg/client/rp/verifier.go
@@ -73,8 +73,10 @@ func VerifyIDToken[C oidc.Claims](ctx context.Context, token string, v *IDTokenV
 		return nilClaims, err
 	}
 
-	if err = oidc.CheckNonce(claims, v.Nonce(ctx)); err != nil {
-		return nilClaims, err
+	if v.Nonce != nil {
+		if err = oidc.CheckNonce(claims, v.Nonce(ctx)); err != nil {
+			return nilClaims, err
+		}
 	}
 
 	if err = oidc.CheckAuthorizationContextClassReference(claims, v.ACR); err != nil {


### PR DESCRIPTION
The `Nonce` func in `IDTokenVerifier` can technically be set to `nil`. We don't want to panic by calling a `nil` func. So I've updated the `VerifyIDToken` func to skip the `nonce` claim check if the func is `nil`.

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

