### PR TITLE
fix: Omit non-standard, empty fields in `RefreshTokenRequest` when performing a token refresh

### DIFF
--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -737,8 +737,8 @@ type RefreshTokenRequest struct {
 	Scopes              oidc.SpaceDelimitedArray `schema:"scope"`
 	ClientID            string                   `schema:"client_id"`
 	ClientSecret        string                   `schema:"client_secret"`
-	ClientAssertion     string                   `schema:"client_assertion"`
-	ClientAssertionType string                   `schema:"client_assertion_type"`
+	ClientAssertion     string                   `schema:"client_assertion,omitempty"`
+	ClientAssertionType string                   `schema:"client_assertion_type,omitempty"`
 	GrantType           oidc.GrantType           `schema:"grant_type"`
 }
 

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -734,9 +734,9 @@ func (t tokenEndpointCaller) TokenEndpoint() string {
 
 type RefreshTokenRequest struct {
 	RefreshToken        string                   `schema:"refresh_token"`
-	Scopes              oidc.SpaceDelimitedArray `schema:"scope"`
-	ClientID            string                   `schema:"client_id"`
-	ClientSecret        string                   `schema:"client_secret"`
+	Scopes              oidc.SpaceDelimitedArray `schema:"scope,omitempty"`
+	ClientID            string                   `schema:"client_id,omitempty"`
+	ClientSecret        string                   `schema:"client_secret,omitempty"`
 	ClientAssertion     string                   `schema:"client_assertion,omitempty"`
 	ClientAssertionType string                   `schema:"client_assertion_type,omitempty"`
 	GrantType           oidc.GrantType           `schema:"grant_type"`


### PR DESCRIPTION
The OIDC spec's definition of a refresh request does not include `client_assertion` or `client_assertion_type` as valid parameters for the refresh request. See request format here: https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken. The document only displays `client_id`, `client_secret`, `grant_type`, `refresh_token`, and `scope` as acceptable parameters.

Therefore, I propose we add the `omitempty` tags to the `ClientAssertion` and `ClientAssertionType` fields in `RefreshTokenRequest`, so that the token refresh functionality provided by `rp.RefreshTokens` can work with identity providers that may have additional logic or different expectations when these fields are included in the refresh token request.

For example, when attempting to construct an OIDC client via `rp.RelyingParty` against an Okta identity provider, I ran into issues when performing refresh with `rp.RefreshTokens`. The Okta identity provider returned `http status not ok: 400 Bad Request {"error":"invalid_request","error_description":"The client_assertion_type is invalid."}` as an error. I assume I'm receiving this error because I'm calling the `RefreshTokens` func with `clientAssertion=""` and `clientAssertionType=""`; the addition of the `omitempty` tags resolves this issue and hopefully future proofs this library against other identity providers that have the same behavior.

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

