### PR TITLE
feat: add default signature algorithm

### DIFF
--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -186,7 +186,7 @@ func toJoseSignatureAlgorithms(algorithms []string) []jose.SignatureAlgorithm {
 		out[i] = jose.SignatureAlgorithm(algorithms[i])
 	}
 	if len(out) == 0 {
-		out = append(out, jose.RS256)
+		out = append(out, jose.RS256, jose.ES256, jose.PS256)
 	}
 	return out
 }


### PR DESCRIPTION
Changed the toJoseSignatureAlgorithms function to support not only RS256 but also ES256 and PS256 when an argument of zero length is given.
See issue #605 for the reason for selecting ES256 and PS256.

### Definition of Ready

- [ ] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
