### PR TITLE
feat(op): allow scope without openid

### DIFF
--- a/pkg/op/auth_request_test.go
+++ b/pkg/op/auth_request_test.go
@@ -138,11 +138,6 @@ func TestValidateAuthRequest(t *testing.T) {
 			oidc.ErrInvalidRequest(),
 		},
 		{
-			"scope openid missing fails",
-			args{&oidc.AuthRequest{Scopes: []string{"profile"}}, mock.NewMockStorageExpectValidClientID(t), nil},
-			oidc.ErrInvalidScope(),
-		},
-		{
 			"response_type missing fails",
 			args{&oidc.AuthRequest{Scopes: []string{"openid"}}, mock.NewMockStorageExpectValidClientID(t), nil},
 			oidc.ErrInvalidRequest(),
@@ -283,16 +278,6 @@ func TestValidateAuthReqScopes(t *testing.T) {
 		{
 			"scopes missing fails",
 			args{},
-			res{
-				err: true,
-			},
-		},
-		{
-			"scope openid missing fails",
-			args{
-				mock.NewClientExpectAny(t, op.ApplicationTypeWeb),
-				[]string{"email"},
-			},
 			res{
 				err: true,
 			},


### PR DESCRIPTION
This changes removes the requirement of the openid scope to be set for all token requests.
As this library also support OAuth2-only authentication mechanisms we still want to sanitize requested scopes, but not enforce the openid scope.

Related to https://github.com/zitadel/zitadel/discussions/8068

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

