### PR TITLE
fix(example): set content-type in the userinfo response

### DIFF
--- a/example/client/app/app.go
+++ b/example/client/app/app.go
@@ -108,6 +108,7 @@ func main() {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("content-type", "application/json")
 		w.Write(data)
 	}
 


### PR DESCRIPTION
This change sets the `content-type` header to `application/json` for the response sent to the browser in the app example.
This enables pretty-printing of the userinfo json document in at least Chromium.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

