### PR TITLE
feat: support PKCS#8

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/zitadel/logging"
+	"go.opentelemetry.io/otel"
+	"golang.org/x/oauth2"
+
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
-	"go.opentelemetry.io/otel"
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -196,12 +197,12 @@ func CallTokenExchangeEndpoint(ctx context.Context, request any, authFn any, cal
 }
 
 func NewSignerFromPrivateKeyByte(key []byte, keyID string) (jose.Signer, error) {
-	privateKey, err := crypto.BytesToPrivateKey(key)
+	privateKey, algorithm, err := crypto.BytesToPrivateKey(key)
 	if err != nil {
 		return nil, err
 	}
 	signingKey := jose.SigningKey{
-		Algorithm: jose.RS256,
+		Algorithm: algorithm,
 		Key:       &jose.JSONWebKey{Key: privateKey, KeyID: keyID},
 	}
 	return jose.NewSigner(signingKey, &jose.SignerOptions{})

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -1,22 +1,45 @@
 package crypto
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+
+	"github.com/go-jose/go-jose/v4"
 )
 
-func BytesToPrivateKey(b []byte) (*rsa.PrivateKey, error) {
+var (
+	ErrPEMDecode             = errors.New("PEM decode failed")
+	ErrUnsupportedFormat     = errors.New("key is neither in PKCS#1 nor PKCS#8 format")
+	ErrUnsupportedPrivateKey = errors.New("unsupported key type, must be RSA, ECDSA or ED25519 private key")
+)
+
+func BytesToPrivateKey(b []byte) (crypto.PublicKey, jose.SignatureAlgorithm, error) {
 	block, _ := pem.Decode(b)
 	if block == nil {
-		return nil, errors.New("PEM decode failed")
+		return nil, "", ErrPEMDecode
 	}
 
-	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err == nil {
+		return privateKey, jose.RS256, nil
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
-		return nil, err
+		return nil, "", ErrUnsupportedFormat
 	}
-
-	return key, nil
+	switch privateKey := key.(type) {
+	case *rsa.PrivateKey:
+		return privateKey, jose.RS256, nil
+	case ed25519.PrivateKey:
+		return privateKey, jose.EdDSA, nil
+	case *ecdsa.PrivateKey:
+		return privateKey, jose.ES256, nil
+	default:
+		return nil, "", ErrUnsupportedPrivateKey
+	}
 }

--- a/pkg/crypto/key_test.go
+++ b/pkg/crypto/key_test.go
@@ -1,21 +1,64 @@
 package crypto_test
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"testing"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/zitadel/oidc/v3/pkg/crypto"
+	zcrypto "github.com/zitadel/oidc/v3/pkg/crypto"
 )
 
-func TestBytesToPrivateKey(tt *testing.T) {
-	tt.Run("PEMDecodeError", func(t *testing.T) {
-		_, err := crypto.BytesToPrivateKey([]byte("The non-PEM sequence"))
-		assert.EqualError(t, err, "PEM decode failed")
-	})
-
-	tt.Run("InvalidKeyFormat", func(t *testing.T) {
-		_, err := crypto.BytesToPrivateKey([]byte(`-----BEGIN PRIVATE KEY-----
+func TestBytesToPrivateKey(t *testing.T) {
+	type args struct {
+		key []byte
+	}
+	type want struct {
+		key       crypto.Signer
+		algorithm jose.SignatureAlgorithm
+		err       error
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "PEMDecodeError",
+			args: args{
+				key: []byte("The non-PEM sequence"),
+			},
+			want: want{
+				err: zcrypto.ErrPEMDecode,
+			},
+		},
+		{
+			name: "PKCS#1 RSA",
+			args: args{
+				key: []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
+KUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm
+o3qGy0t6z09AIJtH+5OeRV1be+N4cDYJKffGzDa88vQENZiRm0GRq6a+HPGQMd2k
+TQIhAKMSvzIBnni7ot/OSie2TmJLY4SwTQAevXysE2RbFDYdAiEBCUEaRQnMnbp7
+9mxDXDf6AU0cN/RPBjb9qSHDcWZHGzUCIG2Es59z8ugGrDY+pxLQnwfotadxd+Uy
+v/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs
+/5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
+-----END RSA PRIVATE KEY-----`),
+			},
+			want: want{
+				key:       &rsa.PrivateKey{},
+				algorithm: jose.RS256,
+				err:       nil,
+			},
+		},
+		{
+			name: "PKCS#8 RSA",
+			args: args{
+				key: []byte(`-----BEGIN PRIVATE KEY-----
 MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCfaDB7pK/fmP/I
 7IusSK8lTCBnPZghqIbVLt2QHYAMoEF1CaF4F4rxo2vl1Mt8gwsq4T3osQFZMvnL
 YHb7KNyUoJgTjLxJQADv2u4Q3U38heAzK5Tp4ry4MCnuyJIqAPK1GiruwEq4zQrx
@@ -42,21 +85,50 @@ srJnjF0H8oKmAY6hw+1Tm/n/b08p+RyL48TgVSE2vhUCgYA3BWpkD4PlCcn/FZsq
 OrLFyFXI6jIaxskFtsRW1IxxIlAdZmxfB26P/2gx6VjLdxJI/RRPkJyEN2dP7CbR
 BDjb565dy1O9D6+UrY70Iuwjz+OcALRBBGTaiF2pLn6IhSzNI2sy/tXX8q8dBlg9
 OFCrqT/emes3KytTPfa5NZtYeQ==
------END PRIVATE KEY-----`))
-		assert.EqualError(t, err, "x509: failed to parse private key (use ParsePKCS8PrivateKey instead for this key format)")
-	})
+-----END PRIVATE KEY-----`),
+			},
+			want: want{
+				key:       &rsa.PrivateKey{},
+				algorithm: jose.RS256,
+				err:       nil,
+			},
+		},
+		{
+			name: "PKCS#8 ECDSA",
+			args: args{
+				key: []byte(`-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgwwOZSU4GlP7ps/Wp
+V6o0qRwxultdfYo/uUuj48QZjSuhRANCAATMiI2Han+ABKmrk5CNlxRAGC61w4d3
+G4TAeuBpyzqJ7x/6NjCxoQzJzZHtNjIfjVATI59XFZWF59GhtSZbShAr
+-----END PRIVATE KEY-----`),
+			},
+			want: want{
+				key:       &ecdsa.PrivateKey{},
+				algorithm: jose.ES256,
+				err:       nil,
+			},
+		},
+		{
+			name: "PKCS#8 ED25519",
+			args: args{
+				key: []byte(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIHu6ZtDsjjauMasBxnS9Fg87UJwKfcT/oiq6S0ktbky8
+-----END PRIVATE KEY-----`),
+			},
+			want: want{
+				key:       ed25519.PrivateKey{},
+				algorithm: jose.EdDSA,
+				err:       nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, algorithm, err := zcrypto.BytesToPrivateKey(tt.args.key)
+			assert.IsType(t, tt.want.key, key)
+			assert.Equal(t, tt.want.algorithm, algorithm)
+			assert.ErrorIs(t, tt.want.err, err)
+		})
 
-	tt.Run("Ok", func(t *testing.T) {
-		key, err := crypto.BytesToPrivateKey([]byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
-KUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm
-o3qGy0t6z09AIJtH+5OeRV1be+N4cDYJKffGzDa88vQENZiRm0GRq6a+HPGQMd2k
-TQIhAKMSvzIBnni7ot/OSie2TmJLY4SwTQAevXysE2RbFDYdAiEBCUEaRQnMnbp7
-9mxDXDf6AU0cN/RPBjb9qSHDcWZHGzUCIG2Es59z8ugGrDY+pxLQnwfotadxd+Uy
-v/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs
-/5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
------END RSA PRIVATE KEY-----`))
-		assert.NoError(t, err)
-		assert.NotNil(t, key)
-	})
+	}
 }

--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/muhlemmer/gu"
+
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 )
 
@@ -344,12 +345,12 @@ func AppendClientIDToAudience(clientID string, audience []string) []string {
 }
 
 func GenerateJWTProfileToken(assertion *JWTProfileAssertionClaims) (string, error) {
-	privateKey, err := crypto.BytesToPrivateKey(assertion.PrivateKey)
+	privateKey, algorithm, err := crypto.BytesToPrivateKey(assertion.PrivateKey)
 	if err != nil {
 		return "", err
 	}
 	key := jose.SigningKey{
-		Algorithm: jose.RS256,
+		Algorithm: algorithm,
 		Key:       &jose.JSONWebKey{Key: privateKey, KeyID: assertion.PrivateKeyID},
 	}
 	signer, err := jose.NewSigner(key, &jose.SignerOptions{})


### PR DESCRIPTION
Until now `BytesToPrivateKey` was only able to handle PKCS#1 RSA keys.
This PR adds support for the PKCS#8 format including RSA, ECDSA or ED25519 private keys.
These keys are used for the signing of JWT, e.g. JWT Profile assertions.

required for https://github.com/zitadel/zitadel-tools/issues/97

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

