### PR TITLE
feat(op): allow returning of parent errors to client

### DIFF
--- a/pkg/oidc/error.go
+++ b/pkg/oidc/error.go
@@ -184,6 +184,13 @@ func (e *Error) WithParent(err error) *Error {
 	return e
 }
 
+// WithReturnParentToClient allows returning the set parent error to the HTTP client.
+// Currently it only supports setting the parent inside JSON responses, not redirect URLs.
+// As Go errors don't unmarshal well, only the marshaller is implemented for the moment.
+//
+// Warning: parent errors may contain sensitive data or unwanted details about the server status.
+// Also, the `parent` field is not a standard error field and might confuse certain clients
+// that require fully compliant responses.
 func (e *Error) WithReturnParentToClient(b bool) *Error {
 	e.returnParent = b
 	return e


### PR DESCRIPTION
This change introduces the possibility to return parent errors to clients. This is implemented by an optional flag on the `*oidc.Error`.

Currently it only support setting the parent inside JSON responses, not redirect URLs. As Go errors don't unmarshall well, only the marshaller is implemented for the moment.

Related to https://github.com/zitadel/zitadel/issues/8362

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

