### PR TITLE
fix: overwrite redirect content length

### DIFF
--- a/pkg/op/server.go
+++ b/pkg/op/server.go
@@ -246,9 +246,7 @@ func NewRedirect(url string) *Redirect {
 }
 
 func (red *Redirect) writeOut(w http.ResponseWriter, r *http.Request) {
-	writerHeader := w.Header()
-	gu.MapMerge(red.Header, writerHeader)
-	writerHeader.Set("Content-Length", "0")
+	gu.MapMerge(red.Header, w.Header())
 	http.Redirect(w, r, red.URL, http.StatusFound)
 }
 

--- a/pkg/op/server.go
+++ b/pkg/op/server.go
@@ -246,7 +246,9 @@ func NewRedirect(url string) *Redirect {
 }
 
 func (red *Redirect) writeOut(w http.ResponseWriter, r *http.Request) {
-	gu.MapMerge(r.Header, w.Header())
+	writerHeader := w.Header()
+	gu.MapMerge(red.Header, writerHeader)
+	writerHeader.Set("Content-Length", "0")
 	http.Redirect(w, r, red.URL, http.StatusFound)
 }
 


### PR DESCRIPTION
The library copies the request headers to response headers. With this change, it copies the redirect struct headers to the response headers.

An example of an issue that the wrong copying caused:

Most HTTP clients add the content-length header to application/x-www-form-urlencoded POST requests. Redirect responses shouldn't have a content however. For example curl fails if the response body length doesn't match the response content-length header.

Before this PRs changes:

![image](https://github.com/user-attachments/assets/b1b482e5-3980-4714-b4ca-d76aec8a173c)

After this PRs changes:

![image](https://github.com/user-attachments/assets/b24f7936-e467-4286-be63-b7ccf450c1e8)

Found while debugging this case:
https://discord.com/channels/927474939156643850/1260630682129010774/1268174893086937099

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

