### PR TITLE
fix(op): initialize http Headers in response objects

### DIFF
--- a/pkg/op/error_test.go
+++ b/pkg/op/error_test.go
@@ -428,7 +428,8 @@ func TestTryErrorRedirect(t *testing.T) {
 				parent: oidc.ErrInteractionRequired().WithDescription("sign in"),
 			},
 			want: &Redirect{
-				URL: "http://example.com/callback?error=interaction_required&error_description=sign+in&state=state1",
+				Header: make(http.Header),
+				URL:    "http://example.com/callback?error=interaction_required&error_description=sign+in&state=state1",
 			},
 			wantLog: `{
 						"level":"WARN",

--- a/pkg/op/server.go
+++ b/pkg/op/server.go
@@ -218,7 +218,8 @@ type Response struct {
 // without custom headers.
 func NewResponse(data any) *Response {
 	return &Response{
-		Data: data,
+		Header: make(http.Header),
+		Data:   data,
 	}
 }
 
@@ -242,7 +243,10 @@ type Redirect struct {
 }
 
 func NewRedirect(url string) *Redirect {
-	return &Redirect{URL: url}
+	return &Redirect{
+		Header: make(http.Header),
+		URL:    url,
+	}
 }
 
 func (red *Redirect) writeOut(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
When creating a new response or new redirect, the `http.Header` maps were left unitialized. This resulted in nil pointer panics when using methods such a `Set`.

This change initializes the `http.Header` maps in the `NewResponse` and `NewRedirect` functions.

Related to https://github.com/zitadel/zitadel/issues/8031 which requires setting of response headers.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

