### PR TITLE
feat(crypto): hash algorithm for EdDSA

### DIFF
--- a/example/client/app/app.go
+++ b/example/client/app/app.go
@@ -56,6 +56,7 @@ func main() {
 		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
 		rp.WithHTTPClient(client),
 		rp.WithLogger(logger),
+		rp.WithSigningAlgsFromDiscovery(),
 	}
 	if clientSecret == "" {
 		options = append(options, rp.WithPKCE(cookieHandler))

--- a/pkg/crypto/hash.go
+++ b/pkg/crypto/hash.go
@@ -22,12 +22,10 @@ func GetHashAlgorithm(sigAlgorithm jose.SignatureAlgorithm) (hash.Hash, error) {
 	case jose.RS512, jose.ES512, jose.PS512:
 		return sha512.New(), nil
 
-	// There is no published spec for this yet.
+	// There is no published spec for this yet, but we have confirmation it will get published.
 	// There is consensus here: https://bitbucket.org/openid/connect/issues/1125/_hash-algorithm-for-eddsa-id-tokens
-	// Currently go-jose only supports the ed25519 curve key for EdDSA, so we can safely assume sha512 here.
-	//
-	// TODO: When go-jose ever decides to support ed448, we need to know the "crv" parameter and use shake256 for ed448.
-	// The "crv" value is currently not exposed by go-jose.JSONWebKey and is currently only hard-coded to be set during marshalling.
+	// Currently Go and go-jose only supports the ed25519 curve key for EdDSA, so we can safely assume sha512 here.
+	// It is unlikely ed448 will ever be supported: https://github.com/golang/go/issues/29390
 	case jose.EdDSA:
 		return sha512.New(), nil
 

--- a/pkg/crypto/hash.go
+++ b/pkg/crypto/hash.go
@@ -21,6 +21,16 @@ func GetHashAlgorithm(sigAlgorithm jose.SignatureAlgorithm) (hash.Hash, error) {
 		return sha512.New384(), nil
 	case jose.RS512, jose.ES512, jose.PS512:
 		return sha512.New(), nil
+
+	// There is no published spec for this yet.
+	// There is consensus here: https://bitbucket.org/openid/connect/issues/1125/_hash-algorithm-for-eddsa-id-tokens
+	// Currently go-jose only supports the ed25519 curve key for EdDSA, so we can safely assume sha512 here.
+	//
+	// TODO: When go-jose ever decides to support ed448, we need to know the "crv" parameter and use shake256 for ed448.
+	// The "crv" value is currently not exposed by go-jose.JSONWebKey and is currently only hard-coded to be set during marshalling.
+	case jose.EdDSA:
+		return sha512.New(), nil
+
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUnsupportedAlgorithm, sigAlgorithm)
 	}

--- a/pkg/oidc/keyset.go
+++ b/pkg/oidc/keyset.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rsa"
 	"errors"
+	"strings"
 
 	jose "github.com/go-jose/go-jose/v4"
 )
@@ -92,17 +93,17 @@ func FindMatchingKey(keyID, use, expectedAlg string, keys ...jose.JSONWebKey) (k
 }
 
 func algToKeyType(key any, alg string) bool {
-	switch alg[0] {
-	case 'R', 'P':
+	if strings.HasPrefix(alg, "RS") || strings.HasPrefix(alg, "PS") {
 		_, ok := key.(*rsa.PublicKey)
 		return ok
-	case 'E':
+	}
+	if strings.HasPrefix(alg, "ES") {
 		_, ok := key.(*ecdsa.PublicKey)
 		return ok
-	case 'O':
-		_, ok := key.(*ed25519.PublicKey)
-		return ok
-	default:
-		return false
 	}
+	if alg == string(jose.EdDSA) {
+		_, ok := key.(ed25519.PublicKey)
+		return ok
+	}
+	return false
 }


### PR DESCRIPTION
This change defines the hasher used for the `at_hash` claim, when the signing key is ed25519.

There is no published spec for this yet.
There is consensus here: https://bitbucket.org/openid/connect/issues/1125/_hash-algorithm-for-eddsa-id-tokens
Currently go-jose only supports the ed25519 curve key for EdDSA, so we can safely assume sha512 here.

Related to https://github.com/zitadel/zitadel/issues/8031

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

