### PR TITLE
chore(example): add supported signing algorithms to RP

### DIFF
--- a/example/client/app/app.go
+++ b/example/client/app/app.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
@@ -53,7 +54,23 @@ func main() {
 
 	options := []rp.Option{
 		rp.WithCookieHandler(cookieHandler),
-		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
+		rp.WithVerifierOpts(
+			rp.WithIssuedAtOffset(5*time.Second),
+			// When the OP uses other signing algorithms then RS256,
+			// We need to tell the RP to accept them.
+			// The actual handshake is done with the "kid" and "alg" header claims.
+			// However, [jose.ParseSigned] needs a list of algorithms we are willing to accept.
+			// This example sets all the algorithms the ZITADEL product supports.
+			rp.WithSupportedSigningAlgorithms(
+				string(jose.EdDSA),
+				string(jose.RS256),
+				string(jose.RS384),
+				string(jose.RS512),
+				string(jose.ES256),
+				string(jose.ES384),
+				string(jose.ES512),
+			),
+		),
 		rp.WithHTTPClient(client),
 		rp.WithLogger(logger),
 	}


### PR DESCRIPTION
This change adds supported signing algorithms the the app example's RP.

This algorithms will be added to zitadel in https://github.com/zitadel/zitadel/pull/8449. This change makes the example work with any of the key types that can be configured in zitadel.

Related to https://github.com/zitadel/zitadel/issues/8031

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

