### PR TITLE
feat: Define redirect uris with env variables

### DIFF
--- a/example/server/exampleop/op.go
+++ b/example/server/exampleop/op.go
@@ -12,21 +12,12 @@ import (
 	"github.com/zitadel/logging"
 	"golang.org/x/text/language"
 
-	"github.com/zitadel/oidc/v3/example/server/storage"
 	"github.com/zitadel/oidc/v3/pkg/op"
 )
 
 const (
 	pathLoggedOut = "/logged-out"
 )
-
-func init() {
-	storage.RegisterClients(
-		storage.NativeClient("native"),
-		storage.WebClient("web", "secret"),
-		storage.WebClient("api", "secret"),
-	)
-}
 
 type Storage interface {
 	op.Storage

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/zitadel/oidc/v3/example/server/exampleop"
 	"github.com/zitadel/oidc/v3/example/server/storage"
@@ -15,6 +16,12 @@ func main() {
 	port := "9998"
 	//which gives us the issuer: http://localhost:9998/
 	issuer := fmt.Sprintf("http://localhost:%s/", port)
+
+	storage.RegisterClients(
+		storage.NativeClient("native", strings.Split(os.Getenv("REDIRECT_URI"), ",")...),
+		storage.WebClient("web", "secret"),
+		storage.WebClient("api", "secret"),
+	)
 
 	// the OpenIDProvider interface needs a Storage interface handling various checks and state manipulations
 	// this might be the layer for accessing your database


### PR DESCRIPTION
We are planning to use Zitadel as an OpenID authentication provider for some of the Camptocamp services. Such a simple customization makes example server more convenient to create E2E tests. Using environment variables instead of command line arguments or config files for easier integration with Docker.