### PR TITLE
feat(oidc): return defined error when discovery failed

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,7 +42,7 @@ func Discover(ctx context.Context, issuer string, httpClient *http.Client, wellK
 	discoveryConfig := new(oidc.DiscoveryConfiguration)
 	err = httphelper.HttpRequest(httpClient, req, &discoveryConfig)
 	if err != nil {
-		return nil, errors.Join(err, oidc.ErrDiscoveryFailed)
+		return nil, errors.Join(oidc.ErrDiscoveryFailed, err)
 	}
 	if logger, ok := logging.FromContext(ctx); ok {
 		logger.Debug("discover", "config", discoveryConfig)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,7 +42,7 @@ func Discover(ctx context.Context, issuer string, httpClient *http.Client, wellK
 	discoveryConfig := new(oidc.DiscoveryConfiguration)
 	err = httphelper.HttpRequest(httpClient, req, &discoveryConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", oidc.ErrDiscoveryFailed, err)
 	}
 	if logger, ok := logging.FromContext(ctx); ok {
 		logger.Debug("discover", "config", discoveryConfig)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,7 +42,7 @@ func Discover(ctx context.Context, issuer string, httpClient *http.Client, wellK
 	discoveryConfig := new(oidc.DiscoveryConfiguration)
 	err = httphelper.HttpRequest(httpClient, req, &discoveryConfig)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", oidc.ErrDiscoveryFailed, err)
+		return nil, errors.Join(err, oidc.ErrDiscoveryFailed)
 	}
 	if logger, ok := logging.FromContext(ctx); ok {
 		logger.Debug("discover", "config", discoveryConfig)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -46,12 +46,7 @@ func TestDiscover(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Discover(context.Background(), tt.args.issuer, http.DefaultClient, tt.args.wellKnownUrl...)
-			if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr)
-				return
-			}
-
-			require.NoError(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
 			if tt.wantFields == nil {
 				return
 			}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -40,9 +40,6 @@ func TestDiscover(t *testing.T) {
 			args: args{
 				issuer: "https://example.com",
 			},
-			wantFields: &wantFields{
-				UILocalesSupported: true,
-			},
 			wantErr: oidc.ErrDiscoveryFailed,
 		},
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
 func TestDiscover(t *testing.T) {
@@ -22,7 +23,7 @@ func TestDiscover(t *testing.T) {
 		name       string
 		args       args
 		wantFields *wantFields
-		wantErr    bool
+		wantErr    error
 	}{
 		{
 			name: "spotify", // https://github.com/zitadel/oidc/issues/406
@@ -32,16 +33,27 @@ func TestDiscover(t *testing.T) {
 			wantFields: &wantFields{
 				UILocalesSupported: true,
 			},
-			wantErr: false,
+			wantErr: nil,
+		},
+		{
+			name: "discovery failed",
+			args: args{
+				issuer: "https://example.com",
+			},
+			wantFields: &wantFields{
+				UILocalesSupported: true,
+			},
+			wantErr: oidc.ErrDiscoveryFailed,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Discover(context.Background(), tt.args.issuer, http.DefaultClient, tt.args.wellKnownUrl...)
-			if tt.wantErr {
-				assert.Error(t, err)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
 				return
 			}
+
 			require.NoError(t, err)
 			if tt.wantFields == nil {
 				return

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -40,6 +40,7 @@ type IDClaims interface {
 
 var (
 	ErrParse                   = errors.New("parsing of request failed")
+	ErrDiscoveryFailed         = errors.New("OpenID Provider Configuration Discovery is failed")
 	ErrIssuerInvalid           = errors.New("issuer does not match")
 	ErrSubjectMissing          = errors.New("subject missing")
 	ErrAudience                = errors.New("audience is not valid")

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -40,8 +40,8 @@ type IDClaims interface {
 
 var (
 	ErrParse                   = errors.New("parsing of request failed")
-	ErrDiscoveryFailed         = errors.New("OpenID Provider Configuration Discovery is failed")
 	ErrIssuerInvalid           = errors.New("issuer does not match")
+	ErrDiscoveryFailed         = errors.New("OpenID Provider Configuration Discovery has failed")
 	ErrSubjectMissing          = errors.New("subject missing")
 	ErrAudience                = errors.New("audience is not valid")
 	ErrAzpMissing              = errors.New("authorized party is not set. If Token is valid for multiple audiences, azp must not be empty")


### PR DESCRIPTION
This PR adds a specific error to handle discovery failures. 
It allows proper error handling when the issuer URL is invalid or the configuration is missing.
Thank you.

### Definition of Ready
- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

