### PR TITLE
fix(example): slice init length for prompt

### DIFF
--- a/example/server/storage/oidc.go
+++ b/example/server/storage/oidc.go
@@ -121,7 +121,7 @@ func (a *AuthRequest) Done() bool {
 }
 
 func PromptToInternal(oidcPrompt oidc.SpaceDelimitedArray) []string {
-	prompts := make([]string, len(oidcPrompt))
+	prompts := make([]string, 0, len(oidcPrompt))
 	for _, oidcPrompt := range oidcPrompt {
 		switch oidcPrompt {
 		case oidc.PromptNone,


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.


The intention here should be to initialize a slice with a capacity of   `len(oidcPrompt`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW



