### PR TITLE
fix(op): add scope to access token scope

### DIFF
--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -230,12 +230,13 @@ func (c *ActorClaims) UnmarshalJSON(data []byte) error {
 }
 
 type AccessTokenResponse struct {
-	AccessToken  string `json:"access_token,omitempty" schema:"access_token,omitempty"`
-	TokenType    string `json:"token_type,omitempty" schema:"token_type,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty" schema:"refresh_token,omitempty"`
-	ExpiresIn    uint64 `json:"expires_in,omitempty" schema:"expires_in,omitempty"`
-	IDToken      string `json:"id_token,omitempty" schema:"id_token,omitempty"`
-	State        string `json:"state,omitempty" schema:"state,omitempty"`
+	AccessToken  string              `json:"access_token,omitempty" schema:"access_token,omitempty"`
+	TokenType    string              `json:"token_type,omitempty" schema:"token_type,omitempty"`
+	RefreshToken string              `json:"refresh_token,omitempty" schema:"refresh_token,omitempty"`
+	ExpiresIn    uint64              `json:"expires_in,omitempty" schema:"expires_in,omitempty"`
+	IDToken      string              `json:"id_token,omitempty" schema:"id_token,omitempty"`
+	State        string              `json:"state,omitempty" schema:"state,omitempty"`
+	Scope        SpaceDelimitedArray `json:"scope,omitempty" schema:"scope,omitempty"`
 }
 
 type JWTProfileAssertionClaims struct {

--- a/pkg/op/device.go
+++ b/pkg/op/device.go
@@ -344,6 +344,7 @@ func CreateDeviceTokenResponse(ctx context.Context, tokenRequest TokenRequest, c
 		RefreshToken: refreshToken,
 		TokenType:    oidc.BearerToken,
 		ExpiresIn:    uint64(validity.Seconds()),
+		Scope:        tokenRequest.GetScopes(),
 	}
 
 	// TODO(v4): remove type assertion

--- a/pkg/op/op_test.go
+++ b/pkg/op/op_test.go
@@ -232,7 +232,7 @@ func TestRoutes(t *testing.T) {
 				"scope":      oidc.SpaceDelimitedArray{oidc.ScopeOpenID, oidc.ScopeOfflineAccess}.String(),
 			},
 			wantCode: http.StatusOK,
-			contains: []string{`{"access_token":"`, `","token_type":"Bearer","expires_in":299}`},
+			contains: []string{`{"access_token":"`, `","token_type":"Bearer","expires_in":299,"scope":"openid offline_access"}`},
 		},
 		{
 			// This call will fail. A successful test is already

--- a/pkg/op/server_http_routes_test.go
+++ b/pkg/op/server_http_routes_test.go
@@ -145,7 +145,7 @@ func TestServerRoutes(t *testing.T) {
 				"assertion":  jwtProfileToken,
 			},
 			wantCode: http.StatusOK,
-			contains: []string{`{"access_token":`, `"token_type":"Bearer","expires_in":299}`},
+			contains: []string{`{"access_token":`, `"token_type":"Bearer","expires_in":299,"scope":"openid"}`},
 		},
 		{
 			name:      "Token exchange",
@@ -174,7 +174,7 @@ func TestServerRoutes(t *testing.T) {
 				"scope":      oidc.SpaceDelimitedArray{oidc.ScopeOpenID, oidc.ScopeOfflineAccess}.String(),
 			},
 			wantCode: http.StatusOK,
-			contains: []string{`{"access_token":"`, `","token_type":"Bearer","expires_in":299}`},
+			contains: []string{`{"access_token":"`, `","token_type":"Bearer","expires_in":299,"scope":"openid offline_access"}`},
 		},
 		{
 			// This call will fail. A successful test is already

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -65,6 +65,7 @@ func CreateTokenResponse(ctx context.Context, request IDTokenRequest, client Cli
 		TokenType:    oidc.BearerToken,
 		ExpiresIn:    exp,
 		State:        state,
+		Scope:        request.GetScopes(),
 	}, nil
 }
 

--- a/pkg/op/token_client_credentials.go
+++ b/pkg/op/token_client_credentials.go
@@ -120,5 +120,6 @@ func CreateClientCredentialsTokenResponse(ctx context.Context, tokenRequest Toke
 		AccessToken: accessToken,
 		TokenType:   oidc.BearerToken,
 		ExpiresIn:   uint64(validity.Seconds()),
+		Scope:       tokenRequest.GetScopes(),
 	}, nil
 }

--- a/pkg/op/token_jwt_profile.go
+++ b/pkg/op/token_jwt_profile.go
@@ -89,6 +89,7 @@ func CreateJWTTokenResponse(ctx context.Context, tokenRequest TokenRequest, crea
 		AccessToken: accessToken,
 		TokenType:   oidc.BearerToken,
 		ExpiresIn:   uint64(validity.Seconds()),
+		Scope:       tokenRequest.GetScopes(),
 	}, nil
 }
 


### PR DESCRIPTION
This attempts to solve [Issue 660](https://github.com/zitadel/oidc/issues/660).

All the details are there. TLDR; Access Token response is not compliant with OAuth 2.0. We decided to _always_ return the `scope` property in the Access Token response to comply with [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).

The implementation consists of getting the scope from the token request, which should be already containing only the scopes that are granted.

### Definition of Ready

- [ ] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

### Further improvements

In my opinion, a more elegant solution would be to strictly adhere with the protocol and only return the scope if has been modified from the request. If compliant, clients could assume all scopes are given by the absence of the `scope` property in the token response, this would avoid parsing the response scope. However, this change would probably cause a breaking change in the exported package, so this solution is good for now.