### PR TITLE
fix: ignore all unmarshal errors from locale

### DIFF
--- a/pkg/oidc/types.go
+++ b/pkg/oidc/types.go
@@ -3,7 +3,6 @@ package oidc
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -78,22 +77,16 @@ func (l *Locale) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-// When [language.ValueError] is encountered, the containing tag will be set
+// All unmarshal errors for are ignored.
+// When an error is encountered, the containing tag will be set
 // to an empty value (language "und") and no error will be returned.
 // This state can be checked with the `l.Tag().IsRoot()` method.
 func (l *Locale) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &l.tag)
-	if err == nil {
-		return nil
-	}
-
-	// catch "well-formed but unknown" errors
-	var target language.ValueError
-	if errors.As(err, &target) {
+	if err != nil {
 		l.tag = language.Tag{}
-		return nil
 	}
-	return err
+	return nil
 }
 
 type Locales []language.Tag

--- a/pkg/oidc/types_test.go
+++ b/pkg/oidc/types_test.go
@@ -232,9 +232,11 @@ func TestLocale_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
-			name:    "bad form, error",
-			input:   `{"locale": "g!!!!!"}`,
-			wantErr: true,
+			name:  "bad form, error",
+			input: `{"locale": "g!!!!!"}`,
+			want: dst{
+				Locale: &Locale{},
+			},
 		},
 	}
 


### PR DESCRIPTION
This changes unmarshal of Locale so that rather than ignoring just `language.ValueError` errors, it ignores all errors. Generally speaking, a bad locale value should not prevent users from authenticating.

Resolves  https://github.com/zitadel/oidc/issues/672
