### PR TITLE
chore(deps): upgrade go to v1.23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.21', '1.22', '1.23']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Whenever possible we tried to reuse / extend existing packages like `OAuth2 for 
 ## Basic Overview
 
 The most important packages of the library:
+
 <pre>
 /pkg
     /client            clients using the OP for retrieving, exchanging and verifying tokens
@@ -36,7 +37,6 @@ The most important packages of the library:
     /client/service    demonstration of JWT Profile Authorization Grant
     /server            examples of an OpenID Provider implementations (including dynamic) with some very basic login UI
 </pre>
-
 
 ### Semver
 
@@ -60,10 +60,13 @@ CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://localhost:9998/ SCOPES="openid 
 - the OP will redirect you to the client app, which displays the user info
 
 for the dynamic issuer, just start it with:
+
 ```bash
 go run github.com/zitadel/oidc/v3/example/server/dynamic
 ```
+
 the oidc web client above will still work, but if you add `oidc.local` (pointing to 127.0.0.1) in your hosts file you can also start it with:
+
 ```bash
 CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://oidc.local:9998/ SCOPES="openid profile" PORT=9999 go run github.com/zitadel/oidc/v3/example/client/app
 ```
@@ -75,35 +78,36 @@ CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://oidc.local:9998/ SCOPES="openid
 Example server allows extra configuration using environment variables and could be used for end to
 end testing of your services.
 
-| Name          | Format                               | Description                           |
-|---------------|--------------------------------------|---------------------------------------|
-| PORT          | Number between 1 and 65535           | OIDC listen port                      |
-| REDIRECT_URI  | Comma-separated URIs                 | List of allowed redirect URIs         |
-| USERS_FILE    | Path to json in local filesystem     | Users with their data and credentials |
+| Name         | Format                           | Description                           |
+| ------------ | -------------------------------- | ------------------------------------- |
+| PORT         | Number between 1 and 65535       | OIDC listen port                      |
+| REDIRECT_URI | Comma-separated URIs             | List of allowed redirect URIs         |
+| USERS_FILE   | Path to json in local filesystem | Users with their data and credentials |
 
 Here is json equivalent for one of the default users
+
 ```json
 {
-    "id2": {
-        "ID":                "id2",
-        "Username":          "test-user2",
-        "Password":          "verysecure",
-        "FirstName":         "Test",
-        "LastName":          "User2",
-        "Email":             "test-user2@zitadel.ch",
-        "EmailVerified":     true,
-        "Phone":             "",
-        "PhoneVerified":     false,
-        "PreferredLanguage": "DE",
-        "IsAdmin":           false
-    }
+  "id2": {
+    "ID": "id2",
+    "Username": "test-user2",
+    "Password": "verysecure",
+    "FirstName": "Test",
+    "LastName": "User2",
+    "Email": "test-user2@zitadel.ch",
+    "EmailVerified": true,
+    "Phone": "",
+    "PhoneVerified": false,
+    "PreferredLanguage": "DE",
+    "IsAdmin": false
+  }
 }
 ```
 
 ## Features
 
 |                      | Relying party | OpenID Provider | Specification                                |
-|----------------------| ------------- | --------------- |----------------------------------------------|
+| -------------------- | ------------- | --------------- | -------------------------------------------- |
 | Code Flow            | yes           | yes             | OpenID Connect Core 1.0, [Section 3.1][1]    |
 | Implicit Flow        | no[^1]        | yes             | OpenID Connect Core 1.0, [Section 3.2][2]    |
 | Hybrid Flow          | no            | not yet         | OpenID Connect Core 1.0, [Section 3.3][3]    |
@@ -117,18 +121,18 @@ Here is json equivalent for one of the default users
 | mTLS                 | not yet       | not yet         | [RFC 8705][11]                               |
 | Back-Channel Logout  | not yet       | yes             | OpenID Connect [Back-Channel Logout][12] 1.0 |
 
-[1]: <https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth> "3.1. Authentication using the Authorization Code Flow"
-[2]: <https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth> "3.2. Authentication using the Implicit Flow"
-[3]: <https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth> "3.3. Authentication using the Hybrid Flow"
-[4]: <https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication> "9. Client Authentication"
-[5]: <https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens> "12. Using Refresh Tokens"
-[6]: <https://openid.net/specs/openid-connect-discovery-1_0.html> "OpenID Connect Discovery 1.0 incorporating errata set 1"
-[7]: <https://www.rfc-editor.org/rfc/rfc7523.html> "JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants"
-[8]: <https://www.rfc-editor.org/rfc/rfc7636.html> "Proof Key for Code Exchange by OAuth Public Clients"
-[9]: <https://www.rfc-editor.org/rfc/rfc8693.html> "OAuth 2.0 Token Exchange"
-[10]: <https://www.rfc-editor.org/rfc/rfc8628.html> "OAuth 2.0 Device Authorization Grant"
-[11]: <https://www.rfc-editor.org/rfc/rfc8705.html> "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens"
-[12]: <https://openid.net/specs/openid-connect-backchannel-1_0.html> "OpenID Connect Back-Channel Logout 1.0 incorporating errata set 1"
+[1]: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth "3.1. Authentication using the Authorization Code Flow"
+[2]: https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth "3.2. Authentication using the Implicit Flow"
+[3]: https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth "3.3. Authentication using the Hybrid Flow"
+[4]: https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication "9. Client Authentication"
+[5]: https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens "12. Using Refresh Tokens"
+[6]: https://openid.net/specs/openid-connect-discovery-1_0.html "OpenID Connect Discovery 1.0 incorporating errata set 1"
+[7]: https://www.rfc-editor.org/rfc/rfc7523.html "JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants"
+[8]: https://www.rfc-editor.org/rfc/rfc7636.html "Proof Key for Code Exchange by OAuth Public Clients"
+[9]: https://www.rfc-editor.org/rfc/rfc8693.html "OAuth 2.0 Token Exchange"
+[10]: https://www.rfc-editor.org/rfc/rfc8628.html "OAuth 2.0 Device Authorization Grant"
+[11]: https://www.rfc-editor.org/rfc/rfc8705.html "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens"
+[12]: https://openid.net/specs/openid-connect-backchannel-1_0.html "OpenID Connect Back-Channel Logout 1.0 incorporating errata set 1"
 
 ## Contributors
 
@@ -153,8 +157,9 @@ Versions that also build are marked with :warning:.
 | Version | Supported          |
 | ------- | ------------------ |
 | <1.21   | :x:                |
-| 1.21    | :white_check_mark: |
+| 1.21    | :warning:          |
 | 1.22    | :white_check_mark: |
+| 1.23    | :white_check_mark: |
 
 ## Why another library
 
@@ -184,6 +189,5 @@ See the exact licensing terms [here](LICENSE)
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
 AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 language governing permissions and limitations under the License.
-
 
 [^1]: https://github.com/zitadel/oidc/issues/135#issuecomment-950563892


### PR DESCRIPTION
Add Go 1.23 to the build matrix and readme.
Some readme diff is because of the pretier formatter.

Related to https://github.com/zitadel/zitadel/issues/8906

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

