### PR TITLE
fix: allow native applications to use https:// on loopback redirect addresses

### DIFF
--- a/pkg/op/auth_request_test.go
+++ b/pkg/op/auth_request_test.go
@@ -434,6 +434,24 @@ func TestValidateAuthReqRedirectURI(t *testing.T) {
 			false,
 		},
 		{
+			"code flow registered https loopback v4 native ok",
+			args{
+				"https://127.0.0.1:4200/callback",
+				mock.NewClientWithConfig(t, []string{"https://127.0.0.1/callback"}, op.ApplicationTypeNative, nil, false),
+				oidc.ResponseTypeCode,
+			},
+			false,
+		},
+		{
+			"code flow registered https loopback v6 native ok",
+			args{
+				"https://[::1]:4200/callback",
+				mock.NewClientWithConfig(t, []string{"https://[::1]/callback"}, op.ApplicationTypeNative, nil, false),
+				oidc.ResponseTypeCode,
+			},
+			false,
+		},
+		{
 			"code flow unregistered http native fails",
 			args{
 				"http://unregistered.com/callback",


### PR DESCRIPTION
This pull request addresses an issue where native clients were unable to utilize HTTPS for redirects on loopback addresses.

**Changes Made:**
- Updated the redirect validation logic to accommodate HTTPS uri's for native applications

Part of this: https://github.com/zitadel/zitadel/issues/4091
