### PR TITLE
feat: add redirect URI-s ENV setting to web clients

### DIFF
--- a/example/server/main.go
+++ b/example/server/main.go
@@ -32,8 +32,8 @@ func main() {
 
 	storage.RegisterClients(
 		storage.NativeClient("native", cfg.RedirectURI...),
-		storage.WebClient("web", "secret"),
-		storage.WebClient("api", "secret"),
+		storage.WebClient("web", "secret", cfg.RedirectURI...),
+		storage.WebClient("api", "secret", cfg.RedirectURI...),
 	)
 
 	// the OpenIDProvider interface needs a Storage interface handling various checks and state manipulations


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

Currently web clients are only working with predefined redirect uris, changed it in a way that web clients are taking those uris from ENV settings.