### PR TITLE
fix: migrate deprecated io/ioutil.ReadFile to os.ReadFile

### DIFF
--- a/pkg/client/key.go
+++ b/pkg/client/key.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 const (
@@ -24,7 +24,7 @@ type KeyFile struct {
 }
 
 func ConfigFromKeyFile(path string) (*KeyFile, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
ioutil package functions where deprecated in Go 1.16. ioutil.ReadFile is the same as os.ReadFile. There was a single reference left in this package. This PR fixes that. 

fix: #713 

https://pkg.go.dev/io/ioutil



### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

