### PR TITLE
feat: add CanGetPrivateClaimsFromRequest interface

### DIFF
--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -144,6 +144,12 @@ type CanSetUserinfoFromRequest interface {
 	SetUserinfoFromRequest(ctx context.Context, userinfo *oidc.UserInfo, request IDTokenRequest, scopes []string) error
 }
 
+// CanGetPrivateClaimsFromRequest is an optional additional interface that may be implemented by
+// implementors of Storage. It allows setting the jwt token claims based on the request.
+type CanGetPrivateClaimsFromRequest interface {
+	GetPrivateClaimsFromRequest(ctx context.Context, request TokenRequest, restrictedScopes []string) (map[string]any, error)
+}
+
 // Storage is a required parameter for NewOpenIDProvider(). In addition to the
 // embedded interfaces below, if the passed Storage implements ClientCredentialsStorage
 // then the grant type "client_credentials" will be supported. In that case, the access

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -147,7 +147,11 @@ func CreateJWT(ctx context.Context, issuer string, tokenRequest TokenRequest, ex
 				tokenExchangeRequest,
 			)
 		} else {
-			privateClaims, err = storage.GetPrivateClaimsFromScopes(ctx, tokenRequest.GetSubject(), client.GetID(), removeUserinfoScopes(restrictedScopes))
+			if fromRequest, ok := storage.(CanGetPrivateClaimsFromRequest); ok {
+				privateClaims, err = fromRequest.GetPrivateClaimsFromRequest(ctx, tokenRequest, removeUserinfoScopes(restrictedScopes))
+			} else {
+				privateClaims, err = storage.GetPrivateClaimsFromScopes(ctx, tokenRequest.GetSubject(), client.GetID(), removeUserinfoScopes(restrictedScopes))
+			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
refs: #323 

added interface CanGetPrivateClaimsFromRequest and added it to CreateJWT for building token claims from an auth token request

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [X] All open todos and follow ups are defined in a new ticket and justified
- [X] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [X] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.

