### PR TITLE
feature(rp): add support for HS256/HS384/HS512 signatures

### DIFF
--- a/pkg/client/rp/verifier_test.go
+++ b/pkg/client/rp/verifier_test.go
@@ -255,7 +255,11 @@ func TestVerifyIDToken(t *testing.T) {
 
 func TestVerifyAccessToken(t *testing.T) {
 	token, _ := tu.ValidAccessToken()
-	hash, err := oidc.ClaimHash(token, tu.SignatureAlgorithm)
+	sigAlgoRS256 := jose.RS256
+	hashRS256, err := oidc.ClaimHash(token, sigAlgoRS256)
+	require.NoError(t, err)
+	sigAlgoHS256 := jose.HS256
+	hashHS256, err := oidc.ClaimHash(token, sigAlgoHS256)
 	require.NoError(t, err)
 
 	type args struct {
@@ -272,18 +276,26 @@ func TestVerifyAccessToken(t *testing.T) {
 			name: "empty hash",
 		},
 		{
-			name: "success",
+			name: "success RS256",
 			args: args{
 				accessToken:  token,
-				atHash:       hash,
-				sigAlgorithm: tu.SignatureAlgorithm,
+				atHash:       hashRS256,
+				sigAlgorithm: sigAlgoRS256,
+			},
+		},
+		{
+			name: "success HS256",
+			args: args{
+				accessToken:  token,
+				atHash:       hashHS256,
+				sigAlgorithm: sigAlgoHS256,
 			},
 		},
 		{
 			name: "invalid algorithm",
 			args: args{
 				accessToken:  token,
-				atHash:       hash,
+				atHash:       hashRS256,
 				sigAlgorithm: "foo",
 			},
 			wantErr: true,
@@ -293,7 +305,7 @@ func TestVerifyAccessToken(t *testing.T) {
 			args: args{
 				accessToken:  token,
 				atHash:       "~~",
-				sigAlgorithm: tu.SignatureAlgorithm,
+				sigAlgorithm: sigAlgoRS256,
 			},
 			wantErr: true,
 		},

--- a/pkg/crypto/hash.go
+++ b/pkg/crypto/hash.go
@@ -15,11 +15,11 @@ var ErrUnsupportedAlgorithm = errors.New("unsupported signing algorithm")
 
 func GetHashAlgorithm(sigAlgorithm jose.SignatureAlgorithm) (hash.Hash, error) {
 	switch sigAlgorithm {
-	case jose.RS256, jose.ES256, jose.PS256:
+	case jose.RS256, jose.ES256, jose.PS256, jose.HS256:
 		return sha256.New(), nil
-	case jose.RS384, jose.ES384, jose.PS384:
+	case jose.RS384, jose.ES384, jose.PS384, jose.HS384:
 		return sha512.New384(), nil
-	case jose.RS512, jose.ES512, jose.PS512:
+	case jose.RS512, jose.ES512, jose.PS512, jose.HS512:
 		return sha512.New(), nil
 
 	// There is no published spec for this yet, but we have confirmation it will get published.

--- a/pkg/oidc/jwt_profile.go
+++ b/pkg/oidc/jwt_profile.go
@@ -7,7 +7,7 @@ type JWTProfileGrantRequest struct {
 }
 
 // NewJWTProfileGrantRequest creates an oauth2 `JSON Web Token (JWT) Profile` Grant
-//`urn:ietf:params:oauth:grant-type:jwt-bearer`
+// `urn:ietf:params:oauth:grant-type:jwt-bearer`
 // sending a self-signed jwt as assertion
 func NewJWTProfileGrantRequest(assertion string, scopes ...string) *JWTProfileGrantRequest {
 	return &JWTProfileGrantRequest{

--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -1,7 +1,7 @@
 package oidc
 
 // EndSessionRequest for the RP-Initiated Logout according to:
-//https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+// https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 type EndSessionRequest struct {
 	IdTokenHint           string `schema:"id_token_hint"`
 	ClientID              string `schema:"client_id"`

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -186,7 +186,7 @@ func toJoseSignatureAlgorithms(algorithms []string) []jose.SignatureAlgorithm {
 		out[i] = jose.SignatureAlgorithm(algorithms[i])
 	}
 	if len(out) == 0 {
-		out = append(out, jose.RS256, jose.ES256, jose.PS256)
+		out = append(out, jose.RS256, jose.ES256, jose.PS256, jose.RS256)
 	}
 	return out
 }


### PR DESCRIPTION
A minor pull request proposed by #412, which introduces support for HS256/HS384/HS512 signatures. 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

