### PR TITLE
fix: Omit Empty Assertion Fields in Device Authorization Request

### DIFF
--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -240,6 +240,6 @@ type ClientCredentialsRequest struct {
 	Scope               SpaceDelimitedArray `schema:"scope"`
 	ClientID            string              `schema:"client_id"`
 	ClientSecret        string              `schema:"client_secret"`
-	ClientAssertion     string              `schema:"client_assertion"`
-	ClientAssertionType string              `schema:"client_assertion_type"`
+	ClientAssertion     string              `schema:"client_assertion,omitempty"`
+	ClientAssertionType string              `schema:"client_assertion_type,omitempty"`
 }


### PR DESCRIPTION
Connected to #744.

This adds the `omitempty` attribute to the client assertion fields used for device authorization. These fields are encoded as form values when calling the `device/authorize` API. When these fields are empty and don't include the `omitempty` attribute, they're being encoded as empty/blank values which can cause issues with some providers, e.g., Okta.

Please let me know if there's anything else I can do to help. I didn't see any relevant unit tests to update.

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

