### PR TITLE
feat: Add appID to be unmarshalled in key file

### DIFF
--- a/pkg/client/key.go
+++ b/pkg/client/key.go
@@ -21,6 +21,7 @@ type KeyFile struct {
 
 	// application
 	ClientID string `json:"clientId"`
+	AppID 	 string `json:"appId"`
 }
 
 func ConfigFromKeyFile(path string) (*KeyFile, error) {


### PR DESCRIPTION
Add appId for Private key for applications. This field was missed from key.go

Format for application private key
```
{"type":"application","keyId":"<KEY_ID>","key":"<PRIVATE_KEY>","appId":"<APP_ID>","clientId":"<CLIENT_ID>"}
```

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

