### PR TITLE
feat: update end session request to pass all params according to specification

### DIFF
--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -1,10 +1,12 @@
 package oidc
 
 // EndSessionRequest for the RP-Initiated Logout according to:
-//https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+// https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 type EndSessionRequest struct {
-	IdTokenHint           string `schema:"id_token_hint"`
-	ClientID              string `schema:"client_id"`
-	PostLogoutRedirectURI string `schema:"post_logout_redirect_uri"`
-	State                 string `schema:"state"`
+	IdTokenHint           string  `schema:"id_token_hint"`
+	LogoutHint            string  `schema:"logout_hint"`
+	ClientID              string  `schema:"client_id"`
+	PostLogoutRedirectURI string  `schema:"post_logout_redirect_uri"`
+	State                 string  `schema:"state"`
+	UILocales             Locales `schema:"ui_locales"`
 }

--- a/pkg/op/session.go
+++ b/pkg/op/session.go
@@ -73,6 +73,8 @@ func ValidateEndSessionRequest(ctx context.Context, req *oidc.EndSessionRequest,
 
 	session := &EndSessionRequest{
 		RedirectURI: ender.DefaultLogoutRedirectURI(),
+		LogoutHint:  req.LogoutHint,
+		UILocales:   req.UILocales,
 	}
 	if req.IdTokenHint != "" {
 		claims, err := VerifyIDTokenHint[*oidc.IDTokenClaims](ctx, req.IdTokenHint, ender.IDTokenHintVerifier(ctx))

--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
+	"golang.org/x/text/language"
 
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
@@ -170,6 +171,8 @@ type EndSessionRequest struct {
 	ClientID          string
 	IDTokenHintClaims *oidc.IDTokenClaims
 	RedirectURI       string
+	LogoutHint        string
+	UILocales         []language.Tag
 }
 
 var ErrDuplicateUserCode = errors.New("user code already exists")


### PR DESCRIPTION
Since the implementation of the end session in this library, the OIDC RP initiated logout specification has been finalized and some additional parameters have been added.

This PR adds `logout_hint` and `ui_locales` to the `EndSessionRequest` to complete the list of possible parameters.
The values are also passed to the corresponding storage type to allow implementations to handle them.

Part of https://github.com/zitadel/zitadel/issues/9847

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

