### PR TITLE
fix: clarify refresh token parameter names and improve code readability

### DIFF
--- a/pkg/op/storage.go
+++ b/pkg/op/storage.go
@@ -41,8 +41,14 @@ type AuthStorage interface {
 	//   registered the refresh_token grant type in advance
 	//
 	// * TokenExchangeRequest as returned by ValidateTokenExchangeRequest
-	CreateAccessAndRefreshTokens(ctx context.Context, request TokenRequest, currentRefreshToken string) (accessTokenID string, newRefreshTokenID string, expiration time.Time, err error)
-	TokenRequestByRefreshToken(ctx context.Context, refreshTokenID string) (RefreshTokenRequest, error)
+	//
+	// CreateAccessAndRefreshToken creates both access and refresh tokens.
+	// The returned refresh token is the actual token value that will be passed
+	// directly to the client. The storage implementation is responsible for
+	// creating the complete refresh token (JWT or opaque format). For refresh tokens,
+	// in either format, the token itself serves as both the identifier and the credential.
+	CreateAccessAndRefreshTokens(ctx context.Context, request TokenRequest, currentRefreshToken string) (accessTokenID string, newRefreshToken string, expiration time.Time, err error)
+	TokenRequestByRefreshToken(ctx context.Context, refreshToken string) (RefreshTokenRequest, error)
 
 	TerminateSession(ctx context.Context, userID string, clientID string) error
 


### PR DESCRIPTION
### Context

While implementing the Storage interface, I discovered that several parameter names were misleading:
  - Parameters named `refreshTokenID` and `newRefreshTokenID` actually contain the full token values, not IDs
  - This naming inconsistency caused confusion about what values should be passed/returned
  - The example implementations already use the semantically correct names (`refreshToken`, `newRefreshToken`), creating a mismatch with the interface definition

  ## Solution

  This PR aligns the interface parameter names with their actual purpose and with the existing example implementations.

  ## Changes

  1. **Storage interface parameter renames:**
     - `TokenRequestByRefreshToken`: `refreshTokenID` → `refreshToken`
     - `CreateAccessAndRefreshTokens`: `newRefreshTokenID` → `newRefreshToken`

  2. **Improved code readability in token.go:**
     - Made bare returns explicit for better clarity
     - Added documentation explaining the token creation flow
     - Clarified why `CreateAccessToken` also returns refresh tokens

  ## Impact

  - **Breaking change**: No - these are parameter name changes in the interface definition only
  - **Behavior change**: No - all logic remains unchanged
  - **Documentation**: Improved with clearer parameter names and added explanations

  ## Testing

  - Ran existing tests (some timing-related test failures are pre-existing and unrelated to these changes)
  - Verified example implementations already use the new parameter names

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [X] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

