### PR TITLE
feat: exclude OTEL instrumentation via build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ CLIENT_ID=web CLIENT_SECRET=secret ISSUER=http://oidc.local:9998/ SCOPES="openid
 
 > Note: Usernames are suffixed with the hostname (`test-user@localhost` or `test-user@oidc.local`)
 
+
+### Build Tags
+
+The library uses build tags to enable or disable features. The following build tags are available:
+
+| Build Tag | Description                                                                                                                                                              |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nootel`  | Disables the OTel instrumentation, which is enabled by default. This is useful if you do not want to use OTel or if you want to use a different instrumentation library. |
+
 ### Server configuration
 
 Example server allows extra configuration using environment variables and could be used for end to

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The library uses build tags to enable or disable features. The following build t
 
 | Build Tag | Description                                                                                                                                                              |
 |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `nootel`  | Disables the OTel instrumentation, which is enabled by default. This is useful if you do not want to use OTel or if you want to use a different instrumentation library. |
+| `no_otel`  | Disables the OTel instrumentation, which is enabled by default. This is useful if you do not want to use OTel or if you want to use a different instrumentation library. |
 
 ### Server configuration
 

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -1,0 +1,12 @@
+//go:build !no_otel
+
+package otel
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Tracer(name string) trace.Tracer {
+	return otel.Tracer(name)
+}

--- a/internal/otel/shim.go
+++ b/internal/otel/shim.go
@@ -1,0 +1,22 @@
+//go:build no_otel
+
+package otel
+
+import (
+	"context"
+)
+
+type FakeTracer struct{}
+type FakeSpan struct{}
+
+func Tracer(name string) FakeTracer {
+	return FakeTracer{}
+}
+
+func (t FakeTracer) Start(ctx context.Context, _ string) (context.Context, FakeSpan) {
+	return ctx, FakeSpan{}
+}
+
+func (s FakeSpan) End() {
+
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/zitadel/logging"
-	"go.opentelemetry.io/otel"
+	"github.com/zitadel/oidc/v3/internal/otel"
 	"golang.org/x/oauth2"
 
 	"github.com/zitadel/oidc/v3/pkg/crypto"

--- a/pkg/op/op.go
+++ b/pkg/op/op.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/rs/cors"
+	"github.com/zitadel/oidc/v3/internal/otel"
 	"github.com/zitadel/schema"
-	"go.opentelemetry.io/otel"
 	"golang.org/x/text/language"
 
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

With this this build tag, downstream programs who not using any instrumentation can exclude whole otel SDK by using a custom build tag. It has binary size effects as well, 600KB in my case.