### PR TITLE
feat: pass optional logout hint and ui locales to end session request

### DIFF
--- a/pkg/client/integration_test.go
+++ b/pkg/client/integration_test.go
@@ -157,7 +157,7 @@ func testRelyingPartySession(t *testing.T, wrapServer bool, cookieSpec cookieSpe
 
 	t.Log("------ end session (logout) ------")
 
-	newLoc, err := rp.EndSession(CTX, provider, tokens.IDToken, "", "")
+	newLoc, err := rp.EndSession(CTX, provider, tokens.IDToken, "", "", "", nil)
 	require.NoError(t, err, "logout")
 	if newLoc != nil {
 		t.Logf("redirect to %s", newLoc)
@@ -313,7 +313,7 @@ func testResourceServerTokenExchange(t *testing.T, wrapServer bool) {
 
 	t.Log("------ end session (logout) ------")
 
-	newLoc, err := rp.EndSession(CTX, provider, tokens.IDToken, "", "")
+	newLoc, err := rp.EndSession(CTX, provider, tokens.IDToken, "", "", "", nil)
 	require.NoError(t, err, "logout")
 	if newLoc != nil {
 		t.Logf("redirect to %s", newLoc)
@@ -451,7 +451,7 @@ func RunAuthorizationCodeFlow(t *testing.T, opServer *httptest.Server, clientID,
 		t.Log("email", info.Email)
 
 		email = info.Email
-		http.Redirect(w, r, targetURL, 302)
+		http.Redirect(w, r, targetURL, http.StatusFound)
 	}
 	rp.CodeExchangeHandler(rp.UserinfoCallback(redirect), provider, rp.WithURLParam("custom", "param"))(capturedW, get)
 

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -799,7 +799,7 @@ func RefreshTokens[C oidc.IDClaims](ctx context.Context, rp RelyingParty, refres
 	return nil, err
 }
 
-func EndSession(ctx context.Context, rp RelyingParty, idToken, optionalRedirectURI, optionalState string) (*url.URL, error) {
+func EndSession(ctx context.Context, rp RelyingParty, idToken, optionalRedirectURI, optionalState, optionalLogoutHint string, optionalLocales oidc.Locales) (*url.URL, error) {
 	ctx = logCtxWithRPData(ctx, rp, "function", "EndSession")
 	ctx, span := client.Tracer.Start(ctx, "RefreshTokens")
 	defer span.End()
@@ -809,6 +809,8 @@ func EndSession(ctx context.Context, rp RelyingParty, idToken, optionalRedirectU
 		ClientID:              rp.OAuthConfig().ClientID,
 		PostLogoutRedirectURI: optionalRedirectURI,
 		State:                 optionalState,
+		LogoutHint:            optionalLogoutHint,
+		UILocales:             optionalLocales,
 	}
 	return client.CallEndSessionEndpoint(ctx, request, nil, rp)
 }


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

# Context

PR https://github.com/zitadel/oidc/pull/754  has introduced the optional logout hint and UI locales to the end session request. However, while working on https://github.com/zitadel/zitadel/pull/10039 , I have noticed that the integration tests on Zitadel side call `relying_party.EndSession()` without the possibility of specifying any logout hint nor ui locales.

This PR adds these 2 parameters to `relying_party.EndSession()` function.