### PR TITLE
perf: optimize custom bool unmarshal

### DIFF
--- a/example/server/storage/storage.go
+++ b/example/server/storage/storage.go
@@ -676,7 +676,7 @@ func (s *Storage) setUserinfo(ctx context.Context, userInfo *oidc.UserInfo, user
 			userInfo.Locale = oidc.NewLocale(user.PreferredLanguage)
 		case oidc.ScopePhone:
 			userInfo.PhoneNumber = user.Phone
-			userInfo.PhoneNumberVerified = user.PhoneVerified
+			userInfo.PhoneNumberVerified = oidc.Bool(user.PhoneVerified)
 		case CustomScope:
 			// you can also have a custom scope and assert public or custom claims based on that
 			userInfo.AppendClaims(CustomClaim, customClaim(clientID))

--- a/pkg/oidc/bool_evolution_bench_test.go
+++ b/pkg/oidc/bool_evolution_bench_test.go
@@ -1,0 +1,177 @@
+package oidc
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// BoolOriginal - The original (Nov 2021) implementation
+type BoolOriginal bool
+
+func (bs *BoolOriginal) UnmarshalJSON(data []byte) error {
+	if string(data) == "true" || string(data) == `"true"` {
+		*bs = true
+	}
+	return nil
+}
+
+// BoolInitialPR - Proposal in https://github.com/zitadel/oidc/pull/791
+// (try bool, fallback to string)
+type BoolFirstPR bool
+
+func (bs *BoolFirstPR) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		*bs = BoolFirstPR(b)
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		switch strings.ToLower(s) {
+		case "true":
+			*bs = true
+			return nil
+		case "false":
+			*bs = false
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cannot unmarshal %s into Bool", data)
+}
+
+// BoolOptimized - Alternative optimized implementation
+// (avoid unnecessary unmarshal attempts)
+type BoolOptimized bool
+
+func (bs *BoolOptimized) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return fmt.Errorf("cannot unmarshal empty data into Bool")
+	}
+
+	switch data[0] {
+	case 't', 'f': // boolean: true or false
+		var b bool
+		if err := json.Unmarshal(data, &b); err != nil {
+			return err
+		}
+		*bs = BoolOptimized(b)
+		return nil
+
+	case '"': // string: "true" or "false"
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		switch strings.ToLower(s) {
+		case "true":
+			*bs = true
+			return nil
+		case "false":
+			*bs = false
+			return nil
+		default:
+			return fmt.Errorf("cannot unmarshal %q into Bool", s)
+		}
+
+	case 'n': // null
+		*bs = false
+		return nil
+
+	default:
+		return fmt.Errorf("cannot unmarshal %s into Bool", data)
+	}
+}
+
+// I wanted to benchmark the different implementations to see how they perform with various inputs.
+// The benchmarks cover standard boolean values, string representations, and null values.
+// The goal is to ensure that the final implementation is both correct and efficient.
+//
+// Below, you'll find a progression of benchmarks for each version of the Bool type,
+// as well as a comparative benchmark simulating a mixed real-world workload.
+var evolutionTests = []struct {
+	name string
+	data []byte
+}{
+	{"BoolTrue", []byte(`true`)},
+	{"BoolFalse", []byte(`false`)},
+	{"StringTrue_AWS", []byte(`"true"`)},
+	{"StringFalse_AWS", []byte(`"false"`)},
+	{"StringTRUE_Mixed", []byte(`"TRUE"`)},
+	{"Null", []byte(`null`)},
+}
+
+func BenchmarkEvolution_1_Original(b *testing.B) {
+	for _, tt := range evolutionTests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var v BoolOriginal
+				_ = v.UnmarshalJSON(tt.data)
+			}
+		})
+	}
+}
+
+func BenchmarkEvolution_2_FirstPR(b *testing.B) {
+	for _, tt := range evolutionTests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var v BoolFirstPR
+				_ = v.UnmarshalJSON(tt.data)
+			}
+		})
+	}
+}
+
+func BenchmarkEvolution_3_Optimized(b *testing.B) {
+	for _, tt := range evolutionTests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var v BoolOptimized
+				_ = v.UnmarshalJSON(tt.data)
+			}
+		})
+	}
+}
+
+// Comparative benchmark for mixed real-world workload
+func BenchmarkEvolution_MixedWorkload(b *testing.B) {
+	// Realistic distribution: 60% standard booleans, 40% AWS Cognito strings
+	workload := [][]byte{
+		[]byte(`true`),
+		[]byte(`false`),
+		[]byte(`true`),
+		[]byte(`"true"`),
+		[]byte(`"false"`),
+	}
+
+	b.Run("1_Original", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var v BoolOriginal
+			_ = v.UnmarshalJSON(workload[i%len(workload)])
+		}
+	})
+
+	b.Run("2_FirstPR", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var v BoolFirstPR
+			_ = v.UnmarshalJSON(workload[i%len(workload)])
+		}
+	})
+
+	b.Run("3_Optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var v BoolOptimized
+			_ = v.UnmarshalJSON(workload[i%len(workload)])
+		}
+	})
+}


### PR DESCRIPTION
### Background

I've submitted a PR [here](https://github.com/zitadel/oidc/pull/791) to bring consistency to the UserInfo claims.

In the process of doing that work, I want to acknowledge that a review might take issue with the apparent decrease in performance my PR introduces. While the correctness fix in my original I would argue as essential, I explored whether we could maintain that correctness while improving performance.

### Analysis

The PR #791 implementation uses a "try standard, fallback to string" approach, which means string values (from AWS Cognito) experience a failed unmarshal attempt before succeeding.

### This Optimization

This PR introduces first-byte detection to determine the JSON type before unmarshaling:
  - `'t'` or `'f'` → boolean value
  - `'"'` → string value
  - `'n'` → null value

By checking the first byte, we avoid unnecessary unmarshal attempts.

### Results

In the interest of transparency, here's the command I ran: `go test -bench=BenchmarkEvolution -benchmem ./pkg/oidc/... -run=^$ -count=2`

And my results with the following

 ```
 Environment:
  - Machine: Apple M1 Ultra
  - OS: darwin/arm64
  - Command: go test -bench=BenchmarkEvolution -benchmem ./pkg/oidc/... -run=^$ -count=2
 ```

```
  Performance Comparison

  | Test Case                  | PR #791 (FirstPR)      | Optimized              | Improvement                  |
  |----------------------------|------------------------|------------------------|------------------------------|
  | String "true" (AWS)        | ~243ns, 392B, 6 allocs | ~123ns, 164B, 3 allocs | 49% faster, 58% less memory  |
  | String "false" (AWS)       | ~247ns, 392B, 6 allocs | ~127ns, 165B, 3 allocs | 49% faster, 58% less memory  |
  | String "TRUE" (mixed case) | ~261ns, 400B, 7 allocs | ~143ns, 176B, 4 allocs | 45% faster, 56% less memory  |
  | Null                       | ~85ns, 145B, 2 allocs  | ~2ns, 0B, 0 allocs     | 97% faster, 100% less memory |
  | Boolean true/false         | ~87-89ns               | ~90-92ns               | Similar (both correct)       |

  Mixed Workload (60% standard booleans, 40% AWS Cognito strings)

  | Implementation    | Time       | Memory          | Allocations      |
  |-------------------|------------|-----------------|------------------|
  | Original (broken) | 0.64ns     | 0B              | 0                |
  | PR #791           | ~160ns     | 243B            | 3                |
  | Optimized         | ~112ns     | 153B            | 2                |
  | Improvement       | 30% faster | 37% less memory | 33% fewer allocs |
```

Raw results here:

```
goos: darwin
     goarch: arm64
     pkg: github.com/zitadel/oidc/v3/pkg/oidc
     cpu: Apple M1 Ultra
     BenchmarkEvolution_1_Original/BoolTrue-20          1000000000               0.3140 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/BoolTrue-20          1000000000               0.3242 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/BoolFalse-20         1000000000               0.3194 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/BoolFalse-20         1000000000               0.3128 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/StringTrue_AWS-20    1000000000               0.3142 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/StringTrue_AWS-20    1000000000               0.3154 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/StringFalse_AWS-20   1000000000               0.3171 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/StringFalse_AWS-20   1000000000               0.3226 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/StringTRUE_Mixed-20  1000000000               0.3184 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/StringTRUE_Mixed-20  1000000000               0.3186 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/Null-20              1000000000               0.3187 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_1_Original/Null-20              1000000000               0.3174 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_2_FirstPR/BoolTrue-20           13917244                85.91 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_2_FirstPR/BoolTrue-20           13489170                88.46 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_2_FirstPR/BoolFalse-20          13084735                88.93 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_2_FirstPR/BoolFalse-20          13768296                89.02 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_2_FirstPR/StringTrue_AWS-20      5043354               238.9 ns/op           392 B/op          6 allocs/op
     BenchmarkEvolution_2_FirstPR/StringTrue_AWS-20      4946833               247.4 ns/op           392 B/op          6 allocs/op
     BenchmarkEvolution_2_FirstPR/StringFalse_AWS-20     4715263               248.6 ns/op           392 B/op          6 allocs/op
     BenchmarkEvolution_2_FirstPR/StringFalse_AWS-20     4909963               244.9 ns/op           392 B/op          6 allocs/op
     BenchmarkEvolution_2_FirstPR/StringTRUE_Mixed-20    4600803               260.2 ns/op           400 B/op          7 allocs/op
     BenchmarkEvolution_2_FirstPR/StringTRUE_Mixed-20    4297750               261.5 ns/op           400 B/op          7 allocs/op
     BenchmarkEvolution_2_FirstPR/Null-20               14263413                85.01 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_2_FirstPR/Null-20               14143027                85.82 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_3_Optimized/BoolTrue-20         13736715                91.75 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_3_Optimized/BoolTrue-20         12832954                90.73 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_3_Optimized/BoolFalse-20        13277493                91.58 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_3_Optimized/BoolFalse-20        13368996                88.90 ns/op          145 B/op          2 allocs/op
     BenchmarkEvolution_3_Optimized/StringTrue_AWS-20   10278966               122.6 ns/op           164 B/op          3 allocs/op
     BenchmarkEvolution_3_Optimized/StringTrue_AWS-20   10014210               122.7 ns/op           164 B/op          3 allocs/op
     BenchmarkEvolution_3_Optimized/StringFalse_AWS-20   9619478               126.1 ns/op           165 B/op          3 allocs/op
     BenchmarkEvolution_3_Optimized/StringFalse_AWS-20   9526398               128.6 ns/op           165 B/op          3 allocs/op
     BenchmarkEvolution_3_Optimized/StringTRUE_Mixed-20                  8277907               141.8 ns/op           176 B/op          4 allocs/op
     BenchmarkEvolution_3_Optimized/StringTRUE_Mixed-20                  8581096               145.1 ns/op           176 B/op          4 allocs/op
     BenchmarkEvolution_3_Optimized/Null-20                             583568294                2.073 ns/op           0 B/op          0 allocs/op
     BenchmarkEvolution_3_Optimized/Null-20                             578041408                2.072 ns/op           0 B/op          0 allocs/op
     BenchmarkEvolution_MixedWorkload/1_Original-20                     1000000000               0.6362 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_MixedWorkload/1_Original-20                     1000000000               0.6448 ns/op          0 B/op          0 allocs/op
     BenchmarkEvolution_MixedWorkload/2_FirstPR-20                       7088049               162.5 ns/op           243 B/op          3 allocs/op
     BenchmarkEvolution_MixedWorkload/2_FirstPR-20                       7507444               157.8 ns/op           243 B/op          3 allocs/op
     BenchmarkEvolution_MixedWorkload/3_Optimized-20                    10828214               113.7 ns/op           153 B/op          2 allocs/op
     BenchmarkEvolution_MixedWorkload/3_Optimized-20                    10842866               111.3 ns/op           153 B/op          2 allocs/op
 ```
 
 ### Should We Merge This?
 
 @muhlemmer / @livio-a - I'll be super transparent - I'm not sure **this optimization is necessary**. The performance gains may be negligible in the broader context of an auth flow that take a few hundred milliseconds. The simpler implementation I have that favors legibility in #791 might be preferable for maintainability.
 
 I'm submitting this as a separate PR so you can evaluate whether the performance improvement justifies the additional complexity. Happy proceed with whichever approach you might prefer - but didn't want you all to think I wasn't taking into account the performance of the work submitted 🤝 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [X] Critical parts are tested automatically
- [X] Where possible E2E tests are implemented
- [X] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.

