### PR TITLE
chore(go): add support for 1.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.23', '1.24']
+        go: ['1.24', '1.25']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Versions that also build are marked with :warning:.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| <1.23   | :x:                |
-| 1.23    | :white_check_mark: |
+| <1.24   | :x:                |
 | 1.24    | :white_check_mark: |
+| 1.25    | :white_check_mark: |
 
 ## Why another library
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/zitadel/oidc/v3
 
-go 1.23.7
-
-toolchain go1.24.1
+go 1.24
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -173,7 +173,7 @@ func ParseRequestObject(ctx context.Context, authReq *oidc.AuthRequest, storage 
 	}
 	keySet := &jwtProfileKeySet{storage: storage, clientID: requestObject.Issuer}
 	if err = oidc.CheckSignature(ctx, authReq.RequestParam, payload, requestObject, nil, keySet); err != nil {
-		return oidc.ErrInvalidRequest().WithParent(err).WithDescription(err.Error())
+		return oidc.ErrInvalidRequest().WithParent(err).WithDescription("invalid request signature")
 	}
 	CopyRequestObjectToAuthRequest(authReq, requestObject)
 	return nil

--- a/pkg/op/server_legacy.go
+++ b/pkg/op/server_legacy.go
@@ -119,8 +119,10 @@ func (s *LegacyServer) Keys(ctx context.Context, r *Request[struct{}]) (*Respons
 	return NewResponse(jsonWebKeySet(keys)), nil
 }
 
+const authReqMissingClientID = "auth request is missing client_id"
+
 var (
-	ErrAuthReqMissingClientID    = errors.New("auth request is missing client_id")
+	ErrAuthReqMissingClientID    = errors.New(authReqMissingClientID)
 	ErrAuthReqMissingRedirectURI = errors.New("auth request is missing redirect_uri")
 )
 
@@ -138,7 +140,7 @@ func (s *LegacyServer) VerifyAuthRequest(ctx context.Context, r *Request[oidc.Au
 		}
 	}
 	if r.Data.ClientID == "" {
-		return nil, oidc.ErrInvalidRequest().WithParent(ErrAuthReqMissingClientID).WithDescription(ErrAuthReqMissingClientID.Error())
+		return nil, oidc.ErrInvalidRequest().WithParent(ErrAuthReqMissingClientID).WithDescription(authReqMissingClientID)
 	}
 	client, err := s.provider.Storage().GetClientByClientID(ctx, r.Data.ClientID)
 	if err != nil {


### PR DESCRIPTION
- Add Go 1.25 to the test matrix
- Oldest supported Go version is now 1.24, as required for https://github.com/zitadel/oidc/pull/796
- Fix non-constant format string build errors

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

