### PR TITLE
fix: add auth_methods client_secret_basic for refresh token and revok…

### DIFF
--- a/example/client/device/device.go
+++ b/example/client/device/device.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
@@ -97,4 +98,18 @@ func main() {
 		logrus.Fatal(err)
 	}
 	logrus.Infof("successfully obtained token: %#v", token)
+
+	logrus.Infof("Going to refresh token")
+	refreshedToken, err := rp.RefreshTokens[*oidc.IDTokenClaims](ctx, provider, token.RefreshToken, "", "")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Infof("refreshedToken: %#v", refreshedToken.Token)
+
+	logrus.Infof("Going to revoke token")
+	err = rp.RevokeToken(ctx, provider, token.AccessToken, "refresh_token")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Info("Token revoked")
 }

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -770,6 +770,12 @@ type RefreshTokenRequest struct {
 	GrantType           oidc.GrantType           `schema:"grant_type"`
 }
 
+func (r RefreshTokenRequest) Auth(req *http.Request) {
+	if r.ClientSecret != "" {
+		req.SetBasicAuth(r.ClientID, r.ClientSecret)
+	}
+}
+
 // RefreshTokens performs a token refresh. If it doesn't error, it will always
 // provide a new AccessToken. It may provide a new RefreshToken, and if it does, then
 // the old one should be considered invalid.

--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"slices"
 	"time"
 
@@ -242,4 +243,10 @@ type ClientCredentialsRequest struct {
 	ClientSecret        string              `schema:"client_secret"`
 	ClientAssertion     string              `schema:"client_assertion,omitempty"`
 	ClientAssertionType string              `schema:"client_assertion_type,omitempty"`
+}
+
+func (r *ClientCredentialsRequest) Auth(req *http.Request) {
+	if r.ClientSecret != "" {
+		req.SetBasicAuth(r.ClientID, r.ClientSecret)
+	}
 }


### PR DESCRIPTION
I have auth provider which supports only auth_methods client_secret_basic

I found that in this case refresh token and revoke token requests do not works
Because basic auth header missed in appropriate http request

Here i try to fit is

I am happy to here feedback and adjust the PT