### PR TITLE
fix grant type in device code validation error message

### DIFF
--- a/pkg/op/device.go
+++ b/pkg/op/device.go
@@ -144,7 +144,7 @@ func ParseDeviceCodeRequest(r *http.Request, o OpenIDProvider) (*oidc.DeviceAuth
 		return nil, err
 	}
 	if !ValidateGrantType(client, oidc.GrantTypeDeviceCode) {
-		return nil, oidc.ErrUnauthorizedClient().WithDescription("client missing grant type " + string(oidc.GrantTypeCode))
+		return nil, oidc.ErrUnauthorizedClient().WithDescription("client missing grant type " + string(oidc.GrantTypeDeviceCode))
 	}
 
 	req := new(oidc.DeviceAuthorizationRequest)


### PR DESCRIPTION
Use `GrantTypeDeviceCode` in device code error message

The error message was incorrectly referencing `GrantTypeCode`(authorization_code) instead of `GrantTypeDeviceCode` when validation failed.