### PR TITLE
fix: propagate signature verification errors correctly

### DIFF
--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -42,6 +42,7 @@ var (
 	ErrIssuerInvalid           = errors.New("issuer does not match")
 	ErrDiscoveryFailed         = errors.New("OpenID Provider Configuration Discovery has failed")
 	ErrSubjectMissing          = errors.New("subject missing")
+	ErrSubjectInvalid          = errors.New("delegation not allowed, issuer and sub must be identical")
 	ErrAudience                = errors.New("audience is not valid")
 	ErrAzpMissing              = errors.New("authorized party is not set. If Token is valid for multiple audiences, azp must not be empty")
 	ErrAzpInvalid              = errors.New("authorized party is not valid")
@@ -194,7 +195,7 @@ func CheckSignature(ctx context.Context, token string, payload []byte, claims Cl
 
 	signedPayload, err := set.VerifySignature(ctx, jws)
 	if err != nil {
-		return fmt.Errorf("%w (%v)", ErrSignatureInvalid, err)
+		return fmt.Errorf("%w (%w)", ErrSignatureInvalid, err)
 	}
 
 	if !bytes.Equal(signedPayload, payload) {

--- a/pkg/op/verifier_jwt_profile.go
+++ b/pkg/op/verifier_jwt_profile.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -106,7 +105,7 @@ type JWTProfileKeyStorage interface {
 // SubjectIsIssuer
 func SubjectIsIssuer(request *oidc.JWTTokenRequest) error {
 	if request.Issuer != request.Subject {
-		return errors.New("delegation not allowed, issuer and sub must be identical")
+		return oidc.ErrSubjectInvalid
 	}
 	return nil
 }

--- a/pkg/op/verifier_jwt_profile_test.go
+++ b/pkg/op/verifier_jwt_profile_test.go
@@ -38,13 +38,13 @@ func TestVerifyJWTAssertion(t *testing.T) {
 		name     string
 		ctx      context.Context
 		newToken func() (string, *oidc.JWTTokenRequest)
-		wantErr  bool
+		wantErr  error
 	}{
 		{
 			name:     "parse error",
 			ctx:      context.Background(),
 			newToken: func() (string, *oidc.JWTTokenRequest) { return "!", nil },
-			wantErr:  true,
+			wantErr:  oidc.ErrParse,
 		},
 		{
 			name: "wrong audience",
@@ -55,7 +55,7 @@ func TestVerifyJWTAssertion(t *testing.T) {
 					time.Now(), tu.ValidExpiration,
 				)
 			},
-			wantErr: true,
+			wantErr: oidc.ErrAudience,
 		},
 		{
 			name: "expired",
@@ -66,7 +66,7 @@ func TestVerifyJWTAssertion(t *testing.T) {
 					time.Now(), time.Now().Add(-time.Hour),
 				)
 			},
-			wantErr: true,
+			wantErr: oidc.ErrExpired,
 		},
 		{
 			name: "invalid iat",
@@ -77,7 +77,7 @@ func TestVerifyJWTAssertion(t *testing.T) {
 					time.Now().Add(time.Hour), tu.ValidExpiration,
 				)
 			},
-			wantErr: true,
+			wantErr: oidc.ErrIatInFuture,
 		},
 		{
 			name: "invalid subject",
@@ -88,13 +88,13 @@ func TestVerifyJWTAssertion(t *testing.T) {
 					time.Now(), tu.ValidExpiration,
 				)
 			},
-			wantErr: true,
+			wantErr: oidc.ErrSubjectInvalid,
 		},
 		{
 			name:     "check signature fail",
 			ctx:      errCtx,
 			newToken: tu.ValidJWTProfileAssertion,
-			wantErr:  true,
+			wantErr:  context.Canceled,
 		},
 		{
 			name:     "ok",
@@ -106,8 +106,8 @@ func TestVerifyJWTAssertion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assertion, want := tt.newToken()
 			got, err := op.VerifyJWTAssertion(tt.ctx, assertion, verifier)
-			if tt.wantErr {
-				assert.Error(t, err)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
# Which Problems Are Solved

The error returned after the signature verification fails is not propagated correctly to the calling function.

# How the Problems Are Solved

The error is wrapped (using the %w verb) instead of embedding (with the %v verb) the error message before returning to the caller.

# Additional Changes
Update test cases to assert the error type.

# Additional Context
- Closes https://github.com/zitadel/oidc/issues/864