### PR TITLE
fix: URL-encode client credentials in Basic Auth per RFC 6749 §2.3.1

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -156,7 +156,7 @@ type RevokeRequest struct {
 
 func (r RevokeRequest) Auth(req *http.Request) {
 	if r.ClientSecret != "" {
-		req.SetBasicAuth(r.ClientID, r.ClientSecret)
+		req.SetBasicAuth(url.QueryEscape(r.ClientID), url.QueryEscape(r.ClientSecret))
 	}
 }
 
@@ -274,7 +274,7 @@ type DeviceAccessTokenRequest struct {
 
 func (r *DeviceAccessTokenRequest) Auth(req *http.Request) {
 	if r.ClientSecret != "" {
-		req.SetBasicAuth(r.ClientID, r.ClientSecret)
+		req.SetBasicAuth(url.QueryEscape(r.ClientID), url.QueryEscape(r.ClientSecret))
 	}
 }
 

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -818,7 +818,7 @@ type RefreshTokenRequest struct {
 
 func (r RefreshTokenRequest) Auth(req *http.Request) {
 	if r.ClientSecret != "" {
-		req.SetBasicAuth(r.ClientID, r.ClientSecret)
+		req.SetBasicAuth(url.QueryEscape(r.ClientID), url.QueryEscape(r.ClientSecret))
 	}
 }
 

--- a/pkg/oidc/token_request.go
+++ b/pkg/oidc/token_request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"time"
 
@@ -247,6 +248,6 @@ type ClientCredentialsRequest struct {
 
 func (r *ClientCredentialsRequest) Auth(req *http.Request) {
 	if r.ClientSecret != "" {
-		req.SetBasicAuth(r.ClientID, r.ClientSecret)
+		req.SetBasicAuth(url.QueryEscape(r.ClientID), url.QueryEscape(r.ClientSecret))
 	}
 }


### PR DESCRIPTION
## Summary

Four `Auth()` methods call `req.SetBasicAuth()` with raw client credentials. Per [RFC 6749 Section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1), client credentials MUST be encoded using the `application/x-www-form-urlencoded` encoding algorithm before being sent via HTTP Basic Authentication.

`net/http.SetBasicAuth` only base64-encodes the credentials — it does not URL-encode them first. When a client secret contains characters like `%`, authorization servers that URL-decode per the RFC (e.g., Keycloak) fail with errors like `URLDecoder: Incomplete trailing escape (%) pattern`.

The existing `AuthorizeBasic()` helper in `pkg/http/http.go` already correctly applies `url.QueryEscape`. This PR applies the same encoding to the four `Auth()` methods that were missing it:

- `RefreshTokenRequest.Auth` (`pkg/client/rp/relying_party.go`)
- `RevokeRequest.Auth` (`pkg/client/client.go`)
- `DeviceAccessTokenRequest.Auth` (`pkg/client/client.go`)
- `ClientCredentialsRequest.Auth` (`pkg/oidc/token_request.go`)

## Related

This is distinct from #857 / #858 (duplicate credentials issue), though both stem from the same `Auth()` methods. This PR fixes the encoding bug without removing the `ClientSecretBasicAuthRequest` interface, so it is not a breaking change.

## Testing

All existing tests pass. The fix is a one-line change per method, consistent with the pattern already used by `AuthorizeBasic()`.