### PR TITLE
fix: remove override error after GetRefreshTokenInfo

### DIFF
--- a/pkg/op/token_revocation.go
+++ b/pkg/op/token_revocation.go
@@ -48,7 +48,7 @@ func Revoke(w http.ResponseWriter, r *http.Request, revoker Revoker) {
 		if err != nil {
 			// An invalid refresh token means that we'll try other things (leaving doDecrypt==true)
 			if !errors.Is(err, ErrInvalidRefreshToken) {
-				RevocationRequestError(w, r, oidc.ErrServerError().WithParent(err))
+				RevocationRequestError(w, r, err)
 				return
 			}
 		} else {


### PR DESCRIPTION

# Which Problems Are Solved

all the error from `GetRefreshTokenInfo` falls to server error. 
because the error got wrapped the on the server error
```
RevocationRequestError(w, r, oidc.ErrServerError().WithParent(err))
```

there is `DefaultToServerError` under `RevocationRequestError`, that it defaults to oidc server err if it's not oidc error. We don't need to override the error to server error from `GetRefreshTokenInfo`
```
func RevocationError(err error) StatusError {
	e := oidc.DefaultToServerError(err, err.Error())
```


