### PR TITLE
chore: replace deprecated labels with issue types in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,6 @@
 name: Bug Report
 description: "Create a bug report to help us improve ZITADEL. Click [here](https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#product-management) to see how we process your issue."
 title: "[Bug]: "
-labels: ["bug"]
 type: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,6 +1,6 @@
 name: 📄 Documentation
 description: Create an issue for missing or wrong documentation.
-labels: ["docs"]
+labels: ["area/docs"]
 type: task
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,6 +1,5 @@
 name: 🛠️ Improvement
 description: "Create a new issue for an improvement in ZITADEL"
-labels: ["enhancement"]
 type: enhancement
 body:
   - type: markdown


### PR DESCRIPTION
## Description

The org is migrating from label-based issue classification to GitHub Issue Types. Issue templates that hardcode `labels:` would silently re-add those labels every time an issue is opened, blocking the cleanup. The `docs` label is also being renamed to `area/docs`.

These templates already declare a `type:`, so the deprecated labels are simply removed (rather than duplicating the type):

- `.github/ISSUE_TEMPLATE/bug_report.yaml` — removed `labels: ["bug"]` (keeps existing `type: Bug`)
- `.github/ISSUE_TEMPLATE/enhancement.yaml` — removed `labels: ["enhancement"]` (keeps existing `type: enhancement`)
- `.github/ISSUE_TEMPLATE/docs.yaml` — `labels: ["docs"]` → `labels: ["area/docs"]`

No other fields were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA7kgVw1fjMW32K7FyPASQ)_