### PR TITLE
fix(op): update stale v3 import in token_request_test.go

### DIFF
--- a/pkg/op/token_request_test.go
+++ b/pkg/op/token_request_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/zitadel/oidc/v3/pkg/oidc"
-	"github.com/zitadel/oidc/v3/pkg/op"
+	"github.com/zitadel/oidc/v4/pkg/oidc"
+	"github.com/zitadel/oidc/v4/pkg/op"
 )
 
 func TestAuthorizeCodeChallenge(t *testing.T) {


### PR DESCRIPTION
# Which Problems Are Solved

- `pkg/op/token_request_test.go` imported `github.com/zitadel/oidc/v3/...` while the module itself is `github.com/zitadel/oidc/v4`, causing the test file to reference a different major version than the rest of the codebase.

# How the Problems Are Solved

- Updated the two imports (`pkg/oidc` and `pkg/op`) in `pkg/op/token_request_test.go` from `v3` to `v4`.

# Additional Changes

None.

# Additional Context

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbHcRepm3aWad8tsRE3ZhT)_