### PR TITLE
fix(rp): use redirect host for CLI callback server

### DIFF
--- a/example/client/app/app.go
+++ b/example/client/app/app.go
@@ -44,7 +44,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	redirectURI := fmt.Sprintf("http://localhost:%v%v", port, callbackPath)
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%v%v", port, callbackPath)
 	cookieHandler := httphelper.NewCookieHandler(key, key, httphelper.WithUnsecure())
 
 	logger := slog.New(

--- a/example/client/github/github.go
+++ b/example/client/github/github.go
@@ -29,7 +29,7 @@ func main() {
 	rpConfig := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  fmt.Sprintf("http://localhost:%v%v", port, callbackPath),
+		RedirectURL:  fmt.Sprintf("http://127.0.0.1:%v%v", port, callbackPath),
 		Scopes:       []string{"repo", "repo_deployment"},
 		Endpoint:     githubOAuth.Endpoint,
 	}

--- a/pkg/client/rp/cli/cli.go
+++ b/pkg/client/rp/cli/cli.go
@@ -2,7 +2,12 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
@@ -28,9 +33,61 @@ func CodeFlow[C oidc.IDClaims](ctx context.Context, relyingParty rp.RelyingParty
 	http.Handle(loginPath, rp.AuthURLHandler(stateProvider, relyingParty))
 	http.Handle(callbackPath, rp.CodeExchangeHandler(callback, relyingParty))
 
-	httphelper.StartServer(codeflowCtx, ":"+port)
+	listenAddress, loginURL, err := callbackServerConfig(relyingParty.OAuthConfig().RedirectURL, callbackPath, port)
+	if err != nil {
+		log.Fatalf("invalid redirect URI: %v", err)
+	}
+	httphelper.StartServer(codeflowCtx, listenAddress)
 
-	OpenBrowser("http://localhost:" + port + loginPath)
+	OpenBrowser(loginURL)
 
 	return <-tokenChan
+}
+
+func callbackServerConfig(redirectURI, callbackPath, port string) (listenAddress, loginURL string, err error) {
+	redirect, err := url.Parse(redirectURI)
+	if err != nil {
+		return "", "", err
+	}
+	if !strings.EqualFold(redirect.Scheme, "http") {
+		return "", "", fmt.Errorf("scheme must be http")
+	}
+	if redirect.User != nil {
+		return "", "", fmt.Errorf("user information is not allowed")
+	}
+	if redirect.Fragment != "" {
+		return "", "", fmt.Errorf("fragment is not allowed")
+	}
+	if redirect.Path != callbackPath {
+		return "", "", fmt.Errorf("callback path %q does not match redirect URI path %q", callbackPath, redirect.Path)
+	}
+
+	host := redirect.Hostname()
+	if host == "" {
+		return "", "", fmt.Errorf("host is required")
+	}
+	redirectPort := redirect.Port()
+	if redirectPort == "" {
+		return "", "", fmt.Errorf("port is required")
+	}
+	if port != redirectPort {
+		return "", "", fmt.Errorf("port %q does not match redirect URI port %q", port, redirectPort)
+	}
+
+	listenHost := host
+	if strings.EqualFold(host, "localhost") {
+		// Preserve the existing dual-stack behavior for localhost. Callers should
+		// prefer an explicit loopback IP to avoid address-family ambiguity.
+		listenHost = ""
+	} else if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		return "", "", fmt.Errorf("host %q is not a loopback address", host)
+	}
+
+	listenAddress = net.JoinHostPort(listenHost, redirectPort)
+	login := url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, redirectPort),
+		Path:   loginPath,
+	}
+	return listenAddress, login.String(), nil
 }

--- a/pkg/client/rp/cli/cli_test.go
+++ b/pkg/client/rp/cli/cli_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallbackServerConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		redirectURI  string
+		callbackPath string
+		port         string
+		wantListen   string
+		wantLoginURL string
+		wantErr      bool
+	}{
+		{
+			name:         "IPv4 loopback",
+			redirectURI:  "http://127.0.0.1:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantListen:   "127.0.0.1:3000",
+			wantLoginURL: "http://127.0.0.1:3000/login",
+		},
+		{
+			name:         "IPv6 loopback",
+			redirectURI:  "http://[::1]:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantListen:   "[::1]:3000",
+			wantLoginURL: "http://[::1]:3000/login",
+		},
+		{
+			name:         "localhost compatibility",
+			redirectURI:  "http://localhost:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantListen:   ":3000",
+			wantLoginURL: "http://localhost:3000/login",
+		},
+		{
+			name:         "missing port",
+			redirectURI:  "http://127.0.0.1/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantErr:      true,
+		},
+		{
+			name:         "port mismatch",
+			redirectURI:  "http://127.0.0.1:3001/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantErr:      true,
+		},
+		{
+			name:         "HTTPS",
+			redirectURI:  "https://127.0.0.1:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantErr:      true,
+		},
+		{
+			name:         "remote host",
+			redirectURI:  "http://example.com:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantErr:      true,
+		},
+		{
+			name:         "localhost lookalike",
+			redirectURI:  "http://localhost.attacker.com:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantErr:      true,
+		},
+		{
+			name:         "IPv4 lookalike",
+			redirectURI:  "http://127.0.0.1.attacker.com:3000/callback",
+			callbackPath: "/callback",
+			port:         "3000",
+			wantErr:      true,
+		},
+		{
+			name:         "callback path mismatch",
+			redirectURI:  "http://127.0.0.1:3000/callback",
+			callbackPath: "/other",
+			port:         "3000",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listenAddress, loginURL, err := callbackServerConfig(tt.redirectURI, tt.callbackPath, tt.port)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantListen, listenAddress)
+			assert.Equal(t, tt.wantLoginURL, loginURL)
+		})
+	}
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -94,8 +94,8 @@ func URLEncodeParams(resp any, encoder Encoder) (url.Values, error) {
 	return values, nil
 }
 
-func StartServer(ctx context.Context, port string) {
-	server := &http.Server{Addr: port}
+func StartServer(ctx context.Context, address string) {
+	server := &http.Server{Addr: address}
 	go func() {
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			log.Fatalf("ListenAndServe(): %v", err)


### PR DESCRIPTION
# Which Problems Are Solved

- The CLI authorization flow always opens `http://localhost:<port>/login`, regardless of the loopback host configured in the redirect URI.
- The callback server always listens on `:<port>`, ignoring an explicit IPv4 or IPv6 loopback address in the redirect URI.
- Consequently, callers cannot ensure that the callback server and browser use the same explicit loopback address.
- Invalid or inconsistent callback configurations are not detected before the server starts.

# How the Problems Are Solved

- Derives both the callback listener address and the browser `/login` URL from the configured redirect URI.
- Binds directly to explicit IPv4 and IPv6 loopback addresses, ensuring that the browser and callback server use the same address family.
- Validates that the redirect URI:
    - uses HTTP
    - contains an explicit port matching the CLI port
    - uses `localhost` or a loopback IP address
    - contains the expected callback path
    - does not contain user information or a fragment
- Preserves the existing `:<port>` listener behavior for callers using `localhost`, avoiding a backward-incompatible single-address-family change.

# Additional Changes

- Updates the client examples to use `127.0.0.1`, avoiding `localhost` address-family ambiguity.
- Renames the `StartServer` parameter from `port` to `address` to reflect that it receives a complete listening address.
- Adds tests covering IPv4, IPv6, existing `localhost` behavior, missing and mismatched ports, non-loopback hosts, hostname lookalikes, HTTPS, and callback path mismatches.

# Additional Context

Callers using an explicit loopback IP now get deterministic address-family behavior. Existing callers using `localhost` retain the previous wildcard listener behavior for compatibility.

Chromium resolves `localhost` to both IPv6 and IPv4, placing the IPv6 loopback address first. This can be observed on macOS by starting separate IPv6 and IPv4 listeners.

In the first terminal:

```console
$ nc -k -6 -l 3000
```

In the second terminal:

```console
$ nc -k -4 -l 3000
```

Both listeners can be confirmed with:

```console
$ lsof -n -P -i:3000
COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
nc      61660 suku    3u  IPv4 0xaf57491278098f95      0t0  TCP *:3000 (LISTEN)
nc      61696 suku    3u  IPv6 0x86b12b3afee37ced      0t0  TCP *:3000 (LISTEN)
```

Opening `http://localhost:3000` in Chromium connects to the IPv6 listener. Because that connection succeeds, Chromium does not need to fall back to IPv4. This demonstrates that `localhost` is not equivalent to explicitly selecting `127.0.0.1`.

Chromium's [`ResolveLocalHostname`](https://source.chromium.org/chromium/chromium/src/+/c70cbba2e0b73e622ff5899294e76974be0083f2:net/dns/host_resolver_manager.cc;l=332) adds the IPv6 loopback address before the IPv4 loopback address.

This is a callback reliability and loopback-hardening change. It does not claim that every wildcard Go listener encounters an address-family failure.