### PR TITLE
feat: support custom issuer verifier

### DIFF
--- a/pkg/client/rp/verifier.go
+++ b/pkg/client/rp/verifier.go
@@ -132,6 +132,7 @@ func NewIDTokenVerifier(issuer, clientID string, keySet oidc.KeySet, options ...
 // VerifierOption is the type for providing dynamic options to the IDTokenVerifier
 type VerifierOption func(*IDTokenVerifier)
 
+// WithISSVerifier sets a custom verifier for validating the `iss` (issuer) claim.
 func WithISSVerifier(verifier oidc.ISSVerifier) VerifierOption {
 	return func(v *IDTokenVerifier) {
 		v.ISS = verifier

--- a/pkg/client/rp/verifier.go
+++ b/pkg/client/rp/verifier.go
@@ -49,7 +49,7 @@ func VerifyIDToken[C oidc.Claims](ctx context.Context, token string, v *IDTokenV
 		return nilClaims, err
 	}
 
-	if err = oidc.CheckIssuer(claims, v.Issuer); err != nil {
+	if err := oidc.CheckIssuerWithISSVerifier(claims, v.Issuer, v.ISS); err != nil {
 		return nilClaims, err
 	}
 
@@ -131,6 +131,12 @@ func NewIDTokenVerifier(issuer, clientID string, keySet oidc.KeySet, options ...
 
 // VerifierOption is the type for providing dynamic options to the IDTokenVerifier
 type VerifierOption func(*IDTokenVerifier)
+
+func WithISSVerifier(issuer string, verifier oidc.ISSVerifier) VerifierOption {
+	return func(v *IDTokenVerifier) {
+		v.ISS = verifier
+	}
+}
 
 // WithIssuedAtOffset mitigates the risk of iat to be in the future
 // because of clock skews with the ability to add an offset to the current time

--- a/pkg/client/rp/verifier.go
+++ b/pkg/client/rp/verifier.go
@@ -132,7 +132,7 @@ func NewIDTokenVerifier(issuer, clientID string, keySet oidc.KeySet, options ...
 // VerifierOption is the type for providing dynamic options to the IDTokenVerifier
 type VerifierOption func(*IDTokenVerifier)
 
-func WithISSVerifier(issuer string, verifier oidc.ISSVerifier) VerifierOption {
+func WithISSVerifier(verifier oidc.ISSVerifier) VerifierOption {
 	return func(v *IDTokenVerifier) {
 		v.ISS = verifier
 	}

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -67,6 +67,7 @@ var (
 // which values need to be set.
 type Verifier struct {
 	Issuer            string
+	ISS               ISSVerifier
 	MaxAgeIAT         time.Duration
 	Offset            time.Duration
 	ClientID          string
@@ -76,6 +77,20 @@ type Verifier struct {
 	AZP               AZPVerifier
 	KeySet            KeySet
 	Nonce             func(ctx context.Context) string
+}
+
+// ISSVerifier specifies the function to be used by the `DefaultVerifier` for validating the iss claim
+type ISSVerifier func(string) error
+
+// DefaultISSVerifier implements `ISSVerifier` returning an error
+// if the iss claim is set and doesn't match the issuer.
+func DefaultISSVerifier(issuer string) ISSVerifier {
+	return func(iss string) error {
+		if iss != issuer {
+			return fmt.Errorf("%w: expected %q but was %q", ErrIssuerInvalid, issuer, iss)
+		}
+		return nil
+	}
 }
 
 // ACRVerifier specifies the function to be used by the `DefaultVerifier` for validating the acr claim
@@ -121,6 +136,13 @@ func CheckIssuer(claims Claims, issuer string) error {
 		return fmt.Errorf("%w: Expected: %s, got: %s", ErrIssuerInvalid, issuer, claims.GetIssuer())
 	}
 	return nil
+}
+
+func CheckIssuerWithISSVerifier(claims Claims, issuer string, ISS ISSVerifier) error {
+	if ISS == nil {
+		return DefaultISSVerifier(issuer)(claims.GetIssuer())
+	}
+	return ISS(claims.GetIssuer())
 }
 
 func CheckAudience(claims Claims, clientID string) error {

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -83,11 +83,11 @@ type Verifier struct {
 type ISSVerifier func(string) error
 
 // DefaultISSVerifier implements `ISSVerifier` returning an error
-// if the iss claim is set and doesn't match the issuer.
+// if the iss claim doesn't match the expected issuer.
 func DefaultISSVerifier(expectIssuer string) ISSVerifier {
 	return func(inputIssuer string) error {
 		if inputIssuer != expectIssuer {
-			return fmt.Errorf("%w: expected %q but was %q", ErrIssuerInvalid, expectIssuer, inputIssuer)
+			return fmt.Errorf("%w: expected: %s, got: %s", ErrIssuerInvalid, expectIssuer, inputIssuer)
 		}
 		return nil
 	}
@@ -139,11 +139,11 @@ func CheckIssuer(claims Claims, issuer string) error {
 	return nil
 }
 
-func CheckIssuerWithISSVerifier(claims Claims, issuer string, ISS ISSVerifier) error {
-	if ISS == nil {
+func CheckIssuerWithISSVerifier(claims Claims, issuer string, issVerifier ISSVerifier) error {
+	if issVerifier == nil {
 		return DefaultISSVerifier(issuer)(claims.GetIssuer())
 	}
-	return ISS(claims.GetIssuer())
+	return issVerifier(claims.GetIssuer())
 }
 
 func CheckAudience(claims Claims, clientID string) error {

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -84,10 +84,10 @@ type ISSVerifier func(string) error
 
 // DefaultISSVerifier implements `ISSVerifier` returning an error
 // if the iss claim is set and doesn't match the issuer.
-func DefaultISSVerifier(issuer string) ISSVerifier {
-	return func(iss string) error {
-		if iss != issuer {
-			return fmt.Errorf("%w: expected %q but was %q", ErrIssuerInvalid, issuer, iss)
+func DefaultISSVerifier(expectIssuer string) ISSVerifier {
+	return func(inputIssuer string) error {
+		if inputIssuer != expectIssuer {
+			return fmt.Errorf("%w: expected %q but was %q", ErrIssuerInvalid, expectIssuer, inputIssuer)
 		}
 		return nil
 	}

--- a/pkg/oidc/verifier.go
+++ b/pkg/oidc/verifier.go
@@ -131,6 +131,7 @@ func CheckSubject(claims Claims) error {
 	return nil
 }
 
+// Deprecated: Use CheckIssuerWithISSVerifier instead
 func CheckIssuer(claims Claims, issuer string) error {
 	if claims.GetIssuer() != issuer {
 		return fmt.Errorf("%w: Expected: %s, got: %s", ErrIssuerInvalid, issuer, claims.GetIssuer())

--- a/pkg/oidc/verifier_test.go
+++ b/pkg/oidc/verifier_test.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,8 +103,23 @@ func TestCheckIssuer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := CheckIssuer(tt.claims, issuer)
 			assert.ErrorIs(t, err, tt.wantErr)
+			err = CheckIssuerWithISSVerifier(tt.claims, issuer, nil)
+			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestCheckIssuerOverrideByISSVerifier(t *testing.T) {
+	alwaysFail := func(issuer string) error {
+		return fmt.Errorf("%w: always fail", ErrIssuerInvalid)
+	}
+	err := CheckIssuerWithISSVerifier(&TokenClaims{Issuer: "foo.bar"}, "foo.bar", alwaysFail)
+	assert.ErrorIs(t, err, ErrIssuerInvalid)
+	alwaysSuccess := func(issuer string) error {
+		return nil
+	}
+	err = CheckIssuerWithISSVerifier(&TokenClaims{Issuer: "foo.bar"}, "differentIssuer", alwaysSuccess)
+	assert.NoError(t, err)
 }
 
 func TestCheckAudience(t *testing.T) {

--- a/pkg/op/verifier_access_token.go
+++ b/pkg/op/verifier_access_token.go
@@ -44,7 +44,7 @@ func VerifyAccessToken[C oidc.Claims](ctx context.Context, token string, v *Acce
 		return nilClaims, err
 	}
 
-	if err := oidc.CheckIssuer(claims, v.Issuer); err != nil {
+	if err := oidc.CheckIssuerWithISSVerifier(claims, v.Issuer, v.ISS); err != nil {
 		return nilClaims, err
 	}
 

--- a/pkg/op/verifier_id_token_hint.go
+++ b/pkg/op/verifier_id_token_hint.go
@@ -60,7 +60,7 @@ func VerifyIDTokenHint[C oidc.Claims](ctx context.Context, token string, v *IDTo
 		return nilClaims, err
 	}
 
-	if err := oidc.CheckIssuer(claims, v.Issuer); err != nil {
+	if err := oidc.CheckIssuerWithISSVerifier(claims, v.Issuer, v.ISS); err != nil {
 		return nilClaims, err
 	}
 


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/oidc/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
-->

# Which Problems Are Solved
Azure split issuer by tenent id `https://login.microsoftonline.com/{tenantid}/v2.0`
when we want support more general users, like both company and personal users, the issuer is dynamically different by the tenent. the discovery endpoint [https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration) shows the `{tenantid}` pattern as well. 

This PR support customized issuer verifier to support dynamic issuer. 

reference: 
https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#find-your-apps-openid-configuration-document-uri

# How the Problems Are Solved

This PR support customized issuer verifier to support dynamic issuer. 

# Additional Changes

change all the usage to use the new function `oidc.CheckIssuerWithISSVerifier(claims, v.Issuer, v.ISS)` 
it does not change current or default usage, just add option to support cusomized issuer verifier. 

# Additional Context


