### PR TITLE
fix(oidc): callTokenEndpoint expiry conversion error

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -87,7 +87,7 @@ func callTokenEndpoint(ctx context.Context, request any, authFn any, caller Toke
 		AccessToken:  tokenRes.AccessToken,
 		TokenType:    tokenRes.TokenType,
 		RefreshToken: tokenRes.RefreshToken,
-		Expiry:       time.Now().UTC().Add(time.Duration(tokenRes.ExpiresIn) * time.Second),
+		Expiry:       time.Now().UTC().Add(tokenRes.ExpiresIn.AsDuration()),
 	}
 	if tokenRes.IDToken != "" {
 		token = token.WithExtra(map[string]any{

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,13 +2,24 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v4/pkg/oidc"
 )
+
+type testTokenEndpointCaller struct {
+	endpoint string
+	client   *http.Client
+}
+
+func (c testTokenEndpointCaller) TokenEndpoint() string    { return c.endpoint }
+func (c testTokenEndpointCaller) HttpClient() *http.Client { return c.client }
 
 func TestDiscover(t *testing.T) {
 	type wantFields struct {
@@ -54,6 +65,37 @@ func TestDiscover(t *testing.T) {
 			if tt.wantFields.UILocalesSupported {
 				assert.NotEmpty(t, got.UILocalesSupported)
 			}
+		})
+	}
+}
+
+func TestCallTokenEndpointExpiry(t *testing.T) {
+	for _, expiresIn := range []int64{1, 10, 3600, 86401} {
+		t.Run(fmt.Sprintf("%d_seconds", expiresIn), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w,
+					`{"access_token":"token","token_type":"Bearer","expires_in":%d}`,
+					expiresIn,
+				)
+			}))
+			defer server.Close()
+
+			caller := testTokenEndpointCaller{
+				endpoint: server.URL,
+				client:   server.Client(),
+			}
+
+			before := time.Now().UTC().Unix()
+			token, err := CallTokenEndpoint(context.Background(), struct{}{}, caller)
+			require.NoError(t, err)
+			after := time.Now().UTC().Unix()
+			tokenExp := token.Expiry.Unix()
+
+			// To prevent test failures where a second ticks just after we measure time.Now
+			// we check (before+expiresIn) <= tokenExp <= (after+expiresIn)
+			require.GreaterOrEqual(t, tokenExp, before+expiresIn)
+			require.LessOrEqual(t, tokenExp, after+expiresIn)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/oidc/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
-->

# Which Problems Are Solved

A bug was introduced in the PR https://github.com/zitadel/oidc/pull/821 which changes `exp` claim in `AccessTokenResponse` from a `int64` to an `oidc.Duration` but does not update `callTokenEndpoint`. Thus, `callTokenEndpoint` still treats it as int64 and and multiples it by `time.second`. This results in an incorrect Expiry value, depending on the `expiresIn` value it can be ahead by 30 years all the way to dates well exceeding the time period of Futurama.

# How the Problems Are Solved

We fix this bug by updating `callTokenEndpoint` to bring in line the intent of #821 

From: `Expiry:       time.Now().UTC().Add(time.Duration(tokenRes.ExpiresIn) * time.Second),`
To: `Expiry:       time.Now().UTC().Add(tokenRes.ExpiresIn.AsDuration()),`

# Additional Changes

We also add a simple regression test for this bug.

# Additional Context

Note this that only impacts v4 and v3 since this change from `int64` to `oidc.Duration` only exists in v4. We encountered this bug when preparing OpenPubkey connect to update from v3 to v4 https://github.com/openpubkey/openpubkey/pull/392