### PR TITLE
fix(op): reject requested_token_type that cannot be issued

### DIFF
--- a/pkg/op/op_test.go
+++ b/pkg/op/op_test.go
@@ -237,6 +237,21 @@ func TestRoutes(t *testing.T) {
 			},
 		},
 		{
+			name:      "Token exchange to jwt token type",
+			method:    http.MethodGet,
+			path:      testProvider.TokenEndpoint().Relative(),
+			basicAuth: &basicAuth{"web", "secret"},
+			values: map[string]string{
+				"grant_type":           string(oidc.GrantTypeTokenExchange),
+				"scope":                oidc.SpaceDelimitedArray{oidc.ScopeOpenID, oidc.ScopeOfflineAccess}.String(),
+				"subject_token":        jwtToken,
+				"subject_token_type":   string(oidc.AccessTokenType),
+				"requested_token_type": string(oidc.JWTTokenType),
+			},
+			wantCode: http.StatusBadRequest,
+			json:     `{"error":"invalid_request","error_description":"requested_token_type is invalid"}`,
+		},
+		{
 			name:      "Client credentials exchange",
 			method:    http.MethodGet,
 			path:      testProvider.TokenEndpoint().Relative(),

--- a/pkg/op/token_exchange.go
+++ b/pkg/op/token_exchange.go
@@ -400,7 +400,7 @@ func CreateTokenExchangeResponse(
 		// oidc.JWTTokenType and other custom token types are not supported for issuing.
 		// In the future it can be considered to have custom tokens generation logic injected via op configuration
 		// or via expanding Storage interface
-		oidc.ErrInvalidRequest().WithDescription("requested_token_type is invalid")
+		return nil, oidc.ErrInvalidRequest().WithDescription("requested_token_type is invalid")
 	}
 
 	exp := uint64(validity.Seconds())


### PR DESCRIPTION
# Which Problems Are Solved

A token exchange asking for `requested_token_type=urn:ietf:params:oauth:token-type:jwt` returns `200` with an empty token:

    {"access_token":"","issued_token_type":"urn:ietf:params:oauth:token-type:jwt","token_type":"","scope":"openid offline_access"}

`ValidateTokenExchangeRequest` accepts the type, since `TokenType.IsSupported` covers all of `AllTokenTypes`. `CreateTokenExchangeResponse` has no case for it, and its `default:` branch builds the error but never returns it, so `token` and `tokenType` stay empty and are marshalled as a success. RFC 8693 §2.2.1 makes `access_token` and `token_type` REQUIRED in a successful response; a client that checks the status code takes the empty string as its token.

# How the Problems Are Solved

Returns the error that branch already constructs, matching the other error paths in the function. The response becomes `400 {"error":"invalid_request","error_description":"requested_token_type is invalid"}`. Behaviour is unchanged for `access_token`, `refresh_token` and `id_token`.

# Additional Changes

Adds a `TestRoutes` case for the jwt requested token type. I verified it fails without the one-line change (`expected: 400, actual: 200`) and passes with it.

# Additional Context

Compatibility: an omitted or empty `requested_token_type` reaches the same `default:` branch, so a `TokenExchangeStorage` that does not default it in `ValidateTokenExchangeRequest` — `pkg/op/storage.go:90` recommends it, nothing enforces it — moves from that same empty `200` to a `400`. Happy to default that case instead of rejecting it, if you would prefer.

`go vet ./...` is clean; `go test -race ./pkg/...` passes apart from the pre-existing `"expires_in":299` assertions, which flake on darwin/arm64 here for reasons unrelated to this change.

