### PR TITLE
fix: tracing key, doc rephrasing and guard slog.SetDefault against nil

### DIFF
--- a/example/server/exampleop/op.go
+++ b/example/server/exampleop/op.go
@@ -35,7 +35,11 @@ func SetupServer(issuer string, storage Storage, logger *slog.Logger, wrapServer
 	// be sure to create a proper crypto random key and manage it securely!
 	key := sha256.Sum256([]byte("test"))
 	keyId := "key1"
-	slog.SetDefault(logger)
+	if logger != nil {
+		// note that this replaces the logger for the whole process, which is
+		// acceptable for this example, but usually not what a library should do.
+		slog.SetDefault(logger)
+	}
 
 	router := chi.NewRouter()
 	router.Use(requestLoggingMiddleware)

--- a/pkg/client/rp/relying_party.go
+++ b/pkg/client/rp/relying_party.go
@@ -878,7 +878,7 @@ func RefreshTokens[C oidc.IDClaims](ctx context.Context, rp RelyingParty, refres
 }
 
 func EndSession(ctx context.Context, rp RelyingParty, idToken, optionalRedirectURI, optionalState, optionalLogoutHint string, optionalLocales oidc.Locales) (*url.URL, error) {
-	ctx, span := client.Tracer.Start(ctx, "RefreshTokens")
+	ctx, span := client.Tracer.Start(ctx, "EndSession")
 	defer span.End()
 
 	request := oidc.EndSessionRequest{

--- a/pkg/op/token_request.go
+++ b/pkg/op/token_request.go
@@ -86,9 +86,14 @@ type AuthenticatedTokenRequest interface {
 	SetClientSecret(string)
 }
 
-// AuthenticatedTokenRequestAuthMethodChecker is a helper interface for IsSetClientAssertion and IsSetClientIDAndClientSecret
-// it is implemented by oidc.AccessTokenRequest and oidc.RefreshTokenRequest
-// implements it can prevent the client from using more than one authentication method in each request
+// AuthenticatedTokenRequestAuthMethodChecker reports which client authentication methods
+// are present on a token request. It is implemented by oidc.AccessTokenRequest and
+// oidc.RefreshTokenRequest.
+//
+// ParseAuthenticatedTokenRequest uses it to reject requests that combine multiple client
+// authentication methods, as required by https://datatracker.ietf.org/doc/html/rfc6749#section-2.3:
+// "The client MUST NOT use more than one authentication method in each request."
+// Requests that do not implement this interface are not checked.
 type AuthenticatedTokenRequestAuthMethodChecker interface {
 	IsSetClientAssertion() bool
 	IsSetClientIDAndClientSecret() bool


### PR DESCRIPTION
- pkg/client/rp/relying_party.go:881 — EndSession tracing span was named "RefreshTokens"; now "EndSession".
- pkg/op/token_request.go:89 — rewrote the AuthenticatedTokenRequestAuthMethodChecker doc comment to say what it does, that ParseAuthenticatedTokenRequest uses it to enforce RFC 6749 §2.3, and that requests not implementing it are skipped.
- example/server/exampleop/op.go:38 — slog.SetDefault(logger) now guarded against a nil logger, with a note that replacing the process-wide logger is example-only behaviour.

<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/oidc/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
-->

# Which Problems Are Solved

- pkg/client/rp/relying_party.go:881 — EndSession tracing span was named "RefreshTokens"; now "EndSession".
- pkg/op/token_request.go:89 — rewrote the AuthenticatedTokenRequestAuthMethodChecker doc comment to say what it does, that ParseAuthenticatedTokenRequest uses it to enforce RFC 6749 §2.3, and that requests not implementing it are skipped.
- example/server/exampleop/op.go:38 — slog.SetDefault(logger) now guarded against a nil logger, with a note that replacing the process-wide logger is example-only behaviour.

# How the Problems Are Solved

# Additional Changes

# Additional Context

