### PR TITLE
fix(client): avoid mutating caller http.Client in CallRevokeEndpoint

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -116,10 +116,11 @@ func CallEndSessionEndpoint(ctx context.Context, request any, authFn any, caller
 		return nil, err
 	}
 	client := caller.HttpClient()
-	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+	cl := *client
+	cl.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	resp, err := client.Do(req)
+	resp, err := cl.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +180,11 @@ func CallRevokeEndpoint(ctx context.Context, request any, authFn any, caller Rev
 	}
 
 	client := caller.HttpClient()
-	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+	cl := *client
+	cl.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	resp, err := client.Do(req)
+	resp, err := cl.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,7 +2,10 @@ package client
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,3 +60,133 @@ func TestDiscover(t *testing.T) {
 		})
 	}
 }
+
+type mockRevokeCaller struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+func (m *mockRevokeCaller) GetRevokeEndpoint() string {
+	return m.endpoint
+}
+
+func (m *mockRevokeCaller) HttpClient() *http.Client {
+	return m.httpClient
+}
+
+type mockEndSessionCaller struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+func (m *mockEndSessionCaller) GetEndSessionEndpoint() string {
+	return m.endpoint
+}
+
+func (m *mockEndSessionCaller) HttpClient() *http.Client {
+	return m.httpClient
+}
+
+func TestCallRevokeEndpoint_CheckRedirectUnchanged(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	customErr := errors.New("custom redirect error")
+	customRedirect := func(_ *http.Request, _ []*http.Request) error {
+		return customErr
+	}
+
+	tests := []struct {
+		name          string
+		initialClient *http.Client
+		checkFn       func(t *testing.T, client *http.Client)
+	}{
+		{
+			name:          "nil CheckRedirect",
+			initialClient: &http.Client{CheckRedirect: nil},
+			checkFn: func(t *testing.T, client *http.Client) {
+				assert.Nil(t, client.CheckRedirect)
+			},
+		},
+		{
+			name:          "custom CheckRedirect",
+			initialClient: &http.Client{CheckRedirect: customRedirect},
+			checkFn: func(t *testing.T, client *http.Client) {
+				require.NotNil(t, client.CheckRedirect)
+				assert.Equal(t, reflect.ValueOf(customRedirect).Pointer(), reflect.ValueOf(client.CheckRedirect).Pointer())
+				assert.ErrorIs(t, client.CheckRedirect(nil, nil), customErr)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caller := &mockRevokeCaller{
+				endpoint:   server.URL,
+				httpClient: tt.initialClient,
+			}
+			req := &RevokeRequest{
+				Token: "test-token",
+			}
+			err := CallRevokeEndpoint(context.Background(), req, nil, caller)
+			require.NoError(t, err)
+			tt.checkFn(t, tt.initialClient)
+		})
+	}
+}
+
+func TestCallEndSessionEndpoint_CheckRedirectUnchanged(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://example.com/callback", http.StatusFound)
+	}))
+	defer server.Close()
+
+	customErr := errors.New("custom redirect error")
+	customRedirect := func(_ *http.Request, _ []*http.Request) error {
+		return customErr
+	}
+
+	tests := []struct {
+		name          string
+		initialClient *http.Client
+		checkFn       func(t *testing.T, client *http.Client)
+	}{
+		{
+			name:          "nil CheckRedirect",
+			initialClient: &http.Client{CheckRedirect: nil},
+			checkFn: func(t *testing.T, client *http.Client) {
+				assert.Nil(t, client.CheckRedirect)
+			},
+		},
+		{
+			name:          "custom CheckRedirect",
+			initialClient: &http.Client{CheckRedirect: customRedirect},
+			checkFn: func(t *testing.T, client *http.Client) {
+				require.NotNil(t, client.CheckRedirect)
+				assert.Equal(t, reflect.ValueOf(customRedirect).Pointer(), reflect.ValueOf(client.CheckRedirect).Pointer())
+				assert.ErrorIs(t, client.CheckRedirect(nil, nil), customErr)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caller := &mockEndSessionCaller{
+				endpoint:   server.URL,
+				httpClient: tt.initialClient,
+			}
+			req := &oidc.EndSessionRequest{
+				IdTokenHint: "test-id-token",
+			}
+			loc, err := CallEndSessionEndpoint(context.Background(), req, nil, caller)
+			require.NoError(t, err)
+			require.NotNil(t, loc)
+			assert.Equal(t, "https://example.com/callback", loc.String())
+			tt.checkFn(t, tt.initialClient)
+		})
+	}
+}
+
+


### PR DESCRIPTION
# Which Problems Are Solved
- Calling `CallRevokeEndpoint` or `CallEndSessionEndpoint` directly mutated the caller's `*http.Client.CheckRedirect` field, permanently stopping the client from following redirects for subsequent HTTP calls and introducing potential data races when shared across goroutines.

# How the Problems Are Solved
- Made a shallow copy (`cl := *client`) prior to setting `CheckRedirect = http.ErrUseLastResponse`, ensuring the caller's `*http.Client` remains untouched while still sharing the underlying `http.Transport`.
- Added unit tests in `pkg/client/client_test.go` covering both endpoints with `nil` and custom `CheckRedirect` handlers.

# Additional Changes
- None

# Additional Context
- Closes #911