### PR TITLE
fix(op): stop double-decoding redirect_uri in authorization requests

### DIFF
--- a/pkg/op/auth_request.go
+++ b/pkg/op/auth_request.go
@@ -335,8 +335,7 @@ func checkURIAgainstRedirects(client Client, uri string) error {
 
 // ValidateAuthReqRedirectURI validates the passed redirect_uri and response_type to the registered uris and client type
 func ValidateAuthReqRedirectURI(client Client, uri string, responseType oidc.ResponseType) error {
-	uri, err := url.QueryUnescape(uri)
-	if uri == "" || err != nil {
+	if uri == "" {
 		return oidc.ErrInvalidRequestRedirectURI().WithDescription("The redirect_uri is missing in the request. " +
 			"Please ensure it is added to the request. If you have any questions, you may contact the administrator of the application.")
 	}

--- a/pkg/op/auth_request_test.go
+++ b/pkg/op/auth_request_test.go
@@ -731,19 +731,23 @@ func TestValidateAuthReqRedirectURI(t *testing.T) {
 			true,
 		},
 		{
-			"code flow encoded redirect_uri should pass after unescaping",
+			// A redirect_uri reaches this validator already decoded by
+			// r.ParseForm, so a percent-encoded literal denotes a
+			// different URI than the one registered and must not match.
+			// Guards against re-introducing a second decode here; see #968.
+			"code flow percent-encoded redirect_uri does not match",
 			args{
 				"https%3A%2F%2Fregistered.com%2Fcallback",
 				mock.NewClientWithConfig(t, []string{"https://registered.com/callback"}, op.ApplicationTypeWeb, nil, false),
 				oidc.ResponseTypeCode,
 			},
-			false,
+			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := op.ValidateAuthReqRedirectURI(tt.args.client, tt.args.uri, tt.args.responseType); (err != nil) != tt.wantErr {
-				t.Errorf("ValidateRedirectURI() error = %v, wantErr %v", err.Error(), tt.wantErr)
+				t.Errorf("ValidateRedirectURI() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/op/server_http_test.go
+++ b/pkg/op/server_http_test.go
@@ -96,6 +96,9 @@ func (c *testClient) RedirectURIs() []string {
 		"http://registered.com/callback",
 		"http://localhost:9999/callback",
 		"custom://callback",
+		// Survive one percent-decode unchanged, but not two.
+		"https://registered.com/callback?p=a%2Fb",
+		"https://registered.com/callback?a=b+c",
 	}
 }
 
@@ -191,6 +194,17 @@ func (s *requestVerifier) VerifyClient(ctx context.Context, r *Request[ClientCre
 		return nil, oidc.ErrServerError()
 	}
 	return s.client, nil
+}
+
+// redirectingAuthorizer verifies like requestVerifier and then completes the
+// authorization request the way a real Server implementation would, so that a
+// test can tell successful validation apart from any error response.
+type redirectingAuthorizer struct {
+	requestVerifier
+}
+
+func (s *redirectingAuthorizer) Authorize(ctx context.Context, r *ClientRequest[oidc.AuthRequest]) (*Redirect, error) {
+	return NewRedirect(r.Client.LoginURL("authReqID")), nil
 }
 
 var testDecoder = func() *schema.Decoder {
@@ -413,6 +427,47 @@ func Test_webServer_authorizeHandler(t *testing.T) {
 				decoder: tt.fields.decoder,
 			}
 			runWebServerTest(t, s.authorizeHandler, tt.r, tt.want)
+		})
+	}
+}
+
+// Test_webServer_authorizeHandler_encodedRedirectURI drives the authorization
+// endpoint over HTTP so that r.ParseForm takes part in the decode. That is the
+// only way to observe a redirect_uri being decoded a second time inside
+// ValidateAuthReqRedirectURI: a registered URI containing "+" or a percent
+// escape comes out of ParseForm exactly as registered, but a further decode
+// alters it and it no longer matches the client configuration.
+// Used to answer 400 invalid_request, see issue #968.
+func Test_webServer_authorizeHandler_encodedRedirectURI(t *testing.T) {
+	client := newClient(clientTypeWeb)
+	for _, redirectURI := range []string{
+		"https://registered.com/callback?p=a%2Fb",
+		"https://registered.com/callback?a=b+c",
+	} {
+		t.Run(redirectURI, func(t *testing.T) {
+			// url.Values.Encode is the encoding every OAuth client applies,
+			// golang.org/x/oauth2 included: once, over the raw redirect_uri.
+			query := url.Values{
+				"client_id":     []string{client.GetID()},
+				"response_type": []string{string(oidc.ResponseTypeCode)},
+				"scope":         []string{"openid"},
+				"redirect_uri":  []string{redirectURI},
+			}.Encode()
+
+			s := &webServer{
+				server:  &redirectingAuthorizer{requestVerifier{client: client}},
+				decoder: testDecoder,
+			}
+			w := httptest.NewRecorder()
+			s.authorizeHandler(w, httptest.NewRequest(http.MethodGet, "/authorize?"+query, nil))
+
+			res := w.Result()
+			body, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusFound, res.StatusCode, "body: %s", body)
+			// http.Redirect resolves the client's relative login URL
+			// against the request path, "/authorize".
+			assert.Equal(t, "/"+client.LoginURL("authReqID"), res.Header.Get("Location"))
 		})
 	}
 }


### PR DESCRIPTION
# Which Problems Are Solved

- Since v3.43.1, a client whose registered redirect URI contains a `+` or a `%XX` escape (for example `https://app.example/cb?p=a%2Fb`) is refused with `invalid_request` ("The requested redirect_uri is missing in the client configuration") even though it sends exactly the registered value.
- `ValidateAuthReqRedirectURI` calls `url.QueryUnescape` on a `redirect_uri` that `r.ParseForm` in `decodeRequest` has already decoded once. The second decode alters the value, and the exact `slices.Contains` match against `client.RedirectURIs()` fails.
- Both entry points are affected: `webServer.authorize` (`op.Server`) and `ValidateAuthRequestClient` (Provider).

# How the Problems Are Solved

- Removes the `url.QueryUnescape` call introduced by #775. Its premise, that `golang.org/x/oauth2` sends `redirect_uri` percent-encoded and the server must undo it, does not hold: `url.Values.Encode` is the wire encoding, `net/http` reverses it in `ParseForm`, and `Config.AuthCodeURL` sets the raw `RedirectURL` and encodes it once (no `QueryEscape` in any release from v0.1.0 to v0.36.0).
- Adds `Test_webServer_authorizeHandler_encodedRedirectURI`, which drives `authorizeHandler` over HTTP via `httptest` with a query built by `url.Values.Encode`, for a registered URI containing `%2F` and one containing `+`, and expects a 302 to the client login URL. The test in #775 called `ValidateAuthReqRedirectURI` directly, so `ParseForm` never ran and a double decode was unobservable; only an HTTP-level test can pin this down.

# Additional Changes

- `TestValidateAuthReqRedirectURI`: the #775 case is inverted. A percent-encoded literal must not match the registered URI, so re-adding a decode fails a test instead of passing one.
- `testClient.RedirectURIs()` gains the two encoded entries; `redirectingAuthorizer` implements `Authorize` so successful validation shows up as a redirect rather than an unimplemented-method error.
- The table loop in `TestValidateAuthReqRedirectURI` printed `err.Error()`, which panics on a nil error whenever a `wantErr: true` case wrongly succeeds. It now prints the error value.

# Additional Context

- Closes #968
- Reverts #775
- #968 holds the full analysis, per-version measurements and a curl reproduction against the example server.
- This is a false-rejection regression, not a security issue: the extra decode could only move the compared value away from what the client sent, never toward an unregistered URI.
